### PR TITLE
Update manifold Phase 1: identity spine + Devices version panel

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"6aa88985-ce53-4b8c-b485-a340cbe3fe20","pid":92426,"procStart":"Tue Jul  7 20:13:44 2026","acquiredAt":1783607165779}

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -240,6 +240,11 @@ jobs:
 
       - name: Build web UI (SvelteKit static)
         working-directory: apps/web
+        env:
+          # Bake the SPA's build identity so __BUILD_COMMIT__/__BUILD_VERSION__
+          # resolve to the real release (not 'dev'). Mirrors the box's build.rs.
+          GIT_COMMIT: ${{ github.sha }}
+          GIT_DESCRIBE: ${{ env.VIRTUES_BUILD_VERSION }}
         run: |
           pnpm install --frozen-lockfile
           pnpm build

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -116,6 +116,22 @@ jobs:
       - name: Build iroh FFI xcframework (macOS, universal)
         run: crates/virtues-iroh-ffi/build-macos.sh
 
+      # Bake the real build identity into the collector so `--version` reports
+      # the release + commit instead of the "unknown" placeholder (update
+      # manifold Phase 1). BSD sed (macOS runner) needs the empty -i arg.
+      - name: Stamp collector version + commit
+        working-directory: apps/mac-source
+        run: |
+          V="${{ steps.version.outputs.VERSION }}"
+          SHA="${GITHUB_SHA:0:7}"
+          DATE="$(date -u +%Y-%m-%d)"
+          sed -i '' \
+            -e "s/static let current = \".*\"/static let current = \"$V\"/" \
+            -e "s/static let buildDate = \".*\"/static let buildDate = \"$DATE\"/" \
+            -e "s/static let gitCommit = \"unknown\"/static let gitCommit = \"$SHA\"/" \
+            Sources/Version.swift
+          grep -E 'current|buildDate|gitCommit' Sources/Version.swift
+
       - name: Build virtues-collector sidecar (Swift)
         working-directory: apps/mac-source
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ tmp/*
 /crates/virtues-registry/target
 /virtues-core/core/
 /virtues-core/.sqlx
+
+# Local Claude Code project state (runtime locks, local settings)
+.claude/

--- a/apps/ios/Virtues/Managers/Tunnel/HTTPWire.swift
+++ b/apps/ios/Virtues/Managers/Tunnel/HTTPWire.swift
@@ -57,6 +57,13 @@ enum HTTPWire {
             head += "\(name): \(value)\r\n"
         }
 
+        // Stamp this app's build identity so the box records it on this device's
+        // row (shown on the Devices page — update-manifold Phase 1). Only when
+        // the caller hasn't set it explicitly.
+        if request.value(forHTTPHeaderField: "X-Virtues-Client") == nil {
+            head += "X-Virtues-Client: \(AppBuild.clientHeader)\r\n"
+        }
+
         let body = request.httpBody ?? Data()
         head += "Content-Length: \(body.count)\r\n"
         head += "Connection: close\r\n"
@@ -121,5 +128,28 @@ enum HTTPWire {
             throw HTTPWireError.malformedResponse("could not build HTTPURLResponse")
         }
         return (body, response)
+    }
+}
+
+/// The app's build identity, reported to the box via the `X-Virtues-Client`
+/// header so it appears on the Devices page (update-manifold Phase 1). Mirrors
+/// the box's `{version, sha, channel}` shape. `sha`/`channel` read from optional
+/// Info.plist keys a CI build phase can set (`GitCommit`, `Channel`); until then
+/// they degrade to `unknown` / `stable` rather than blocking.
+enum AppBuild {
+    static var version: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0"
+    }
+    static var sha: String {
+        let v = Bundle.main.infoDictionary?["GitCommit"] as? String
+        return (v?.isEmpty == false) ? v! : "unknown"
+    }
+    static var channel: String {
+        let v = Bundle.main.infoDictionary?["Channel"] as? String
+        return (v?.isEmpty == false) ? v! : "stable"
+    }
+    /// The `X-Virtues-Client` header value: `version=…; sha=…; channel=…`.
+    static var clientHeader: String {
+        "version=\(version); sha=\(sha); channel=\(channel)"
     }
 }

--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -1,10 +1,13 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
 
-// Build-time constants injected by Vite (see vite.config.ts)
-declare const __BUILD_COMMIT__: string;
-
 declare global {
+	// Build-time constants injected by Vite (see vite.config.ts). Declared inside
+	// `declare global` (not at top level) because this file is a module (`export
+	// {}`), so a top-level `declare const` would be module-scoped, not global.
+	const __BUILD_COMMIT__: string;
+	const __BUILD_VERSION__: string;
+
 	namespace App {
 		// interface Error {}
 		// interface Locals {} - No server-side locals in static build

--- a/apps/web/src/lib/build.ts
+++ b/apps/web/src/lib/build.ts
@@ -1,0 +1,74 @@
+// The SPA's own build identity — {version, sha, channel} baked at build time by
+// Vite (see vite.config.ts) and mirroring the box's build.rs/codename.rs so every
+// artifact reports the same shape. This is what "this browser" sends to the box in
+// the X-Virtues-Client header and shows on the Devices page.
+// See docs/update-identity-spine.md.
+
+export type Channel = 'stable' | 'staging' | 'edge' | 'dev';
+
+export interface BuildInfo {
+	/** Clean version, e.g. "0.2.0" or "0.1.0-staging.57" or "dev". */
+	version: string;
+	/** Short git commit, e.g. "13cfd9c", or "dev" for untagged local builds. */
+	sha: string;
+	channel: Channel;
+}
+
+/** Derive the release channel from the raw build tag — same rules as the box's
+ *  codename::channel(): bare vX.Y.Z → stable; anything with `staging`/`edge`/an
+ *  offset → the matching prerelease track; empty/dev → dev. */
+function deriveChannel(rawVersion: string): Channel {
+	if (!rawVersion || rawVersion === 'dev') return 'dev';
+	if (rawVersion.includes('staging')) return 'staging';
+	if (rawVersion.startsWith('edge')) return 'edge';
+	if (rawVersion.includes('-')) return 'dev'; // e.g. v0.2.0-4-gabc123 / -dirty
+	return 'stable';
+}
+
+const rawVersion = typeof __BUILD_VERSION__ !== 'undefined' ? __BUILD_VERSION__ : 'dev';
+const rawSha = typeof __BUILD_COMMIT__ !== 'undefined' ? __BUILD_COMMIT__ : 'dev';
+
+export const BUILD: BuildInfo = {
+	version: rawVersion.replace(/^v/, ''),
+	sha: rawSha === 'dev' ? 'dev' : rawSha.slice(0, 7),
+	channel: deriveChannel(rawVersion)
+};
+
+/** Compact one-line identity for display, e.g. "0.2.0 (13cfd9c) · stable". */
+export function buildLabel(b: BuildInfo = BUILD): string {
+	const sha = b.sha && b.sha !== 'dev' ? ` (${b.sha})` : '';
+	return `${b.version}${sha} · ${b.channel}`;
+}
+
+/** The value for the X-Virtues-Client request header. */
+export function clientHeader(b: BuildInfo = BUILD): string {
+	return `version=${b.version}; sha=${b.sha}; channel=${b.channel}`;
+}
+
+/**
+ * Install a one-time global fetch interceptor that stamps `X-Virtues-Client` on
+ * same-origin box requests, so the box can record this browser's build on its
+ * device row (shown on the Devices page). Idempotent and SSR-safe. Only touches
+ * string/URL inputs (the codebase's `fetch(url, init)` pattern) — Request-object
+ * calls pass through untouched to avoid body/stream re-wrapping hazards.
+ */
+export function installClientHeader(): void {
+	if (typeof window === 'undefined') return;
+	const w = window as unknown as { __virtuesFetchPatched?: boolean };
+	if (w.__virtuesFetchPatched) return;
+	w.__virtuesFetchPatched = true;
+
+	const orig = window.fetch.bind(window);
+	const header = clientHeader();
+	window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+		if (typeof input === 'string' || input instanceof URL) {
+			const url = typeof input === 'string' ? input : input.href;
+			if (url.startsWith('/') || url.startsWith(window.location.origin)) {
+				const headers = new Headers(init?.headers);
+				if (!headers.has('X-Virtues-Client')) headers.set('X-Virtues-Client', header);
+				return orig(input, { ...init, headers });
+			}
+		}
+		return orig(input, init);
+	};
+}

--- a/apps/web/src/lib/components/tabs/views/DevicesView.svelte
+++ b/apps/web/src/lib/components/tabs/views/DevicesView.svelte
@@ -45,6 +45,11 @@
 		paired_at: string;
 		last_seen_at: string | null;
 		paired_from_ip: string | null;
+		// Reported build identity (X-Virtues-Client header). Null until the
+		// device has checked in on a build that reports it.
+		version: string | null;
+		sha: string | null;
+		channel: string | null;
 		is_current: boolean;
 	};
 
@@ -266,6 +271,15 @@
 								{/if}
 							</div>
 							<div class="text-xs text-foreground-muted mt-1 flex flex-wrap gap-x-3 gap-y-1">
+								{#if device.version}
+									<span class="font-mono text-foreground"
+										>{device.version}{device.sha && device.sha !== "dev"
+											? ` · ${device.sha}`
+											: ""}{device.channel ? ` · ${device.channel}` : ""}</span
+									>
+								{:else}
+									<span class="italic">version unknown</span>
+								{/if}
 								<span>Last seen {formatTimeAgo(device.last_seen_at)}</span>
 								<span>Paired {formatTimeAgo(device.paired_at)}</span>
 								{#if device.paired_from_ip}

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -29,8 +29,14 @@
 	import { page } from "$app/stores";
 	import type { Snippet } from "svelte";
 
+	import { installClientHeader } from "$lib/build";
+
 	// @ts-ignore — Vite compile-time constant (see vite.config.ts + app.d.ts)
 	const BUILD_COMMIT: string = __BUILD_COMMIT__;
+
+	// Stamp X-Virtues-Client on box requests so this browser's build shows up on
+	// the Devices page (update-manifold Phase 1). Idempotent, SSR-safe.
+	installClientHeader();
 
 	// Get session expiry from page data
 	// Note: children is intentionally not rendered - this app uses a custom tab-based routing system

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,7 +10,14 @@ export default defineConfig(({ mode }) => {
 		envDir: '../..', // Load .env from project root
 		plugins: [tailwindcss(), sveltekit()],
 		define: {
+			// Build identity, baked at build time — mirrors the box's build.rs.
+			// GIT_COMMIT = full sha; GIT_DESCRIBE = the release tag (CI sets
+			// VIRTUES_BUILD_VERSION on shallow checkouts). channel is derived from
+			// the tag in $lib/build. See docs/update-identity-spine.md.
 			'__BUILD_COMMIT__': JSON.stringify(process.env.GIT_COMMIT || 'dev'),
+			'__BUILD_VERSION__': JSON.stringify(
+				process.env.GIT_DESCRIBE || process.env.VIRTUES_BUILD_VERSION || 'dev'
+			),
 		},
 		server: {
 			fs: {

--- a/docs/update-identity-spine.md
+++ b/docs/update-identity-spine.md
@@ -1,0 +1,103 @@
+# Phase 1 — the identity spine + the Devices version panel
+
+The first, cheapest, zero-risk step of [the update manifold](update-manifold-plan.md).
+No behavior change, no gating — just make **every artifact state its identity**, get
+each device to **report it to the box**, and **show the fleet on the Devices page**.
+
+This is deliberately the invisible-plumbing step given a visible destination: when
+it's done, the Devices page shows every paired thing's version at a glance.
+
+## Scope
+
+**In:** a canonical `{version, sha, channel}` baked into every artifact; each client
+reporting it to the box; the box storing it per-device; the Devices page rendering it.
+
+**Out (later phases, don't build here):**
+- The *verdict* — "update required" / "supported" badges. That's a min-version compare
+  (Phase 3, the lattice); this phase only *displays* versions.
+- "Update available" nudges — needs a latest-version source (App Store feed / fleet
+  manifest); deferred.
+- The signed fleet release manifest.
+
+## The canonical identity
+
+One shape, everywhere. Reuse what the box already bakes.
+
+```
+version   semver "0.3.0"        from the git tag (GIT_DESCRIBE)
+sha       "13cfd9c"             git rev-parse HEAD — the unambiguous one
+channel   stable|staging|edge   currently inferred from the tag; make it FIRST-CLASS (baked)
+```
+
+`built_at` is nice-to-have (box already bakes it). `channel` is the one genuinely-new
+field — today it's derived ad hoc from the tag string; bake it as its own constant so
+every artifact reports it uniformly.
+
+## Per-artifact stamping
+
+The box is the reference — already correct. The work is the five stragglers.
+
+| Artifact | Where | State today | Do |
+|----------|-------|-------------|----|
+| **Box** `virtues` | `virtues-core/build.rs`, `/health` (`server/mod.rs:945`) | ✅ bakes SHA/describe/time | add `channel` as a first-class baked const |
+| **SPA** | `apps/web/vite.config.ts:13`, `app.d.ts:5` | `__BUILD_COMMIT__` only (sha), falls back `'dev'` | extend to `__BUILD__ = {version, sha, channel}`; surface in Settings |
+| **Desktop client** (Rust) | `apps/desktop/Cargo.toml` | Cargo version only, no SHA | add a `build.rs` mirroring core |
+| **Mac collector** (Swift) | `apps/mac-source/Sources/Version.swift`; CI `release-mac.yml` | `gitCommit = "unknown"` (never set) | stamp `gitCommit`/`buildDate` in CI at build |
+| **Cloud** virtues-api / atlas | `services/*/src/routes/health.rs` | `/health` has `version` only | bake sha/channel, add to `/health` |
+
+CI already passes `GIT_COMMIT` to the SPA build and `VIRTUES_BUILD_VERSION` to core —
+so the values exist in the pipeline; this is mostly wiring them into each build's
+constants, not new infrastructure.
+
+## Device → box reporting (how the Devices page gets data)
+
+Two touchpoints, both mostly-existing:
+
+1. **At pair time** — the client includes its identity in the `device_info` blob the
+   pairing upsert already writes (`api/pair.rs:908`). No migration: `device_info` and
+   `last_seen_at` already exist (`migrations/0002_auth.sql`).
+2. **On the wire** — clients send a lightweight `X-Virtues-Client:
+   version=…; sha=…; channel=…` header on box requests; the box refreshes that device
+   row's `device_info` + `last_seen_at`. This keeps the version fresh as the app
+   auto-updates, not frozen at pair time.
+
+Box side:
+- `api/devices.rs` `DeviceListItem` (line 31) gains `version` / `sha` / `channel`,
+  read out of `device_info`; add them to the `SELECT` at line 46.
+- Everything else (the row, `last_seen_at`, `kind`, `label`) already exists.
+
+## The Devices page panel
+
+`apps/web/.../tabs/views/DevicesView.svelte` already enumerates every paired thing —
+just add columns. Per row:
+
+```
+Label            Kind        Version         Channel   Last seen
+This browser     web         0.3.0 (13cfd9c) stable    now
+iPhone           ios         1.0.15          stable    2m ago
+MacBook          mac         1.1.0           stable    1h ago
+Sensor / box     box         0.3.0           stable    —
+```
+
+v1 = **display only**: `version · channel · last seen`. That alone answers "is the
+phone way behind the browser?" at a glance. The **badge** (🟢 supported / 🔴 update
+required) is the first thing Phase 3 lights up — it slots into this same row when the
+min-version compare exists. Don't build the verdict here; leave room for it.
+
+Optional, cheap add: the box already reads cloud `/health`; surface atlas/api versions
+in `SystemInfoView` so the box's own "upstream" is visible too.
+
+## Acceptance criteria
+
+- `virtues --version`, the SPA Settings screen, the mac app, the collector, and each
+  cloud `/health` all report `{version, sha, channel}` in the same shape.
+- A freshly paired device shows its version on the Devices page; it updates (not just
+  at pair time) after the client sends a request post-upgrade.
+- No gating, no refusal, no new migration. Pure additive display.
+
+## Why first
+
+It's a day or two, risk-free, and it's the prerequisite for *everything* downstream:
+the lattice's min-version checks (Phase 3) and every future bug report both need "what
+is this thing?" to have an answer. This step makes that answer exist — and puts it on
+a screen.

--- a/docs/update-manifold-plan.md
+++ b/docs/update-manifold-plan.md
@@ -1,0 +1,226 @@
+# The update manifold & compatibility lattice
+
+The first 0.3 feature. How the whole Virtues fleet — not just the box — moves
+between builds coherently, and how components that **never update atomically**
+stay compatible across the gaps.
+
+This generalizes [the box update paradigm](update-paradigm.md) (5 pillars for
+`virtues upgrade`) from one node to the whole system, and adds the piece the box
+doc never needed: cross-component version negotiation.
+
+## Why now
+
+v0.2.0 is the first stable release. Every release from here touches **nine
+independently-versioned artifacts** with almost no coordination between them.
+The audit (2026-07-19) found the fleet has:
+
+- **Five unsynchronized client version numbers** — Tauri app `1.0.x`, native iOS
+  `1.1`, collector `1.0.0`, desktop client `0.1.0`, SPA `0.0.1` — and **no git-SHA
+  on any client** (the collector's `gitCommit` is the literal string `"unknown"`).
+- **Exactly two enforced compatibility gates in the entire system**: iOS honoring
+  the box's `min_ios_version` (`apps/ios/.../DeviceManager.swift:195`), and restore
+  refusing a newer backup schema against a **hardcoded** `KNOWN_MAX_MIGRATION = 9`
+  (`cli/restore.rs:159`) that must be hand-bumped and already drifts.
+- **No cloud version discipline** — atlas + virtues-api ship as `:latest` via manual
+  `docker pull`+restart over SSM; the one "notify Atlas to roll a version" hook
+  (`register-version` in `docker-build.yml`) POSTs to an endpoint that **does not
+  exist** and is `continue-on-error`.
+- **A contradiction in the box itself**: the paradigm doc's Pillar 2 wants migration
+  lineage to *refuse* a mismatched upgrade, but `database/mod.rs:293` boots with
+  `set_ignore_missing(true)` — the guard is off at runtime, live only on restore.
+
+There is no single artifact that says "release R = {box vX, api vY, mac vZ, …} and
+these are the versions that are known to work together." Building that — and the
+negotiation that enforces it at each boundary — is this project.
+
+## Two problems, named
+
+- **The manifold** — the *delivery* surface. One spoke per node-type (box, cloud,
+  mac desktop, mobile shell, mobile SPA, iOS collector, relay, model bucket), each
+  with its own transport (systemd swap, docker pull, Tauri updater, App Store, iroh
+  OTA), unified under a **common build identity** and a **single fleet release
+  manifest**.
+- **The lattice** — the *compatibility* graph. Every edge where two
+  non-atomically-updated components talk, carrying a declared, negotiated
+  version/capability contract instead of an implicit one.
+
+The manifold makes a release coherent; the lattice makes a partial rollout safe.
+
+## The fleet inventory (grounded, 2026-07-19)
+
+| Node | Artifact | Delivery today | Version identity | Gap |
+|------|----------|----------------|------------------|-----|
+| **Box** | `virtues` + sidecars | `virtues upgrade` (naive subset of 5 pillars); installer | `build.rs` bakes SHA/describe/time; `/health` | migration guard off at boot; in-place refresh, partial rollback |
+| **Cloud: virtues-api** (= oauth proxy) | Docker image | CI→GHCR **and** make→ECR (conflicting); manual SSM restart | per-svc `/health` version | `:latest`, two registries, no pin/rollback, dead `set-version` |
+| **Cloud: atlas** | Docker image | `make deploy-atlas` from a laptop, **no CI** | `/health` version | no automated build at all |
+| **Relay** | upstream `iroh-relay` | manual `ssh` + `cargo install`/scp + `systemctl restart` | `^1` semver range | unit-in-git ≠ unit-on-host; manual; unpinned |
+| **Mac desktop** | Tauri v2 app | `tauri-plugin-updater`, minisign, `mac-latest/latest.json` | stamped `tauri.conf.json` | **edge has no feed**; bundled sidecars reconciled by byte-diff, not version |
+| **Mobile shell** | Tauri iOS/Android | App Store (manual) | `CFBundle*` = `1.0.15` | **no updater compiled for mobile** |
+| **Mobile SPA** | SvelteKit bundle | — | **none emitted** | OTA is a *parked plan*, not built |
+| **iOS collector** | native `apps/ios` **or** Tauri mobile (ambiguous) | manual Xcode → TestFlight | `MARKETING_VERSION 1.1` | **no CI/fastlane**; two codebases, unclear which ships |
+| **Models** | GGUF bucket | manual `workflow_dispatch` → GH Release `models-1` | fixed tag | decoupled from every release tag; hand-triggered |
+
+## Design principles
+
+1. **Identity before orchestration.** You cannot coordinate what you cannot name.
+   Every artifact must carry the same shape of build identity before anything
+   negotiates on it.
+2. **Declare compatibility once, enforce at every edge.** The compatibility matrix
+   lives in one signed manifest; each boundary reads it, rather than each pair
+   inventing its own check.
+3. **Refuse, don't brick.** Every boundary and every swap fails *before* committing,
+   with a specific reason — never half-applied. (The box paradigm's Pillar 2/3,
+   generalized.)
+4. **Non-atomic by assumption.** Never require two components to update together.
+   Every edge must degrade or refuse gracefully across a version skew window.
+5. **One spine, many spokes.** Keep each node's native transport (Tauri updater,
+   App Store, systemd, docker) — unify the *identity, channel, and manifest*, not
+   the delivery mechanism.
+
+## Part 1 — The manifold
+
+### 1.1 A common build identity (`BUILD` manifest)
+
+Extend the box's `build.rs` pattern to **every** artifact. Each build emits a
+`BUILD` manifest (baked constant + a `BUILD.json` shipped *inside* the release
+artifact — today it exists only inside backup tarballs, not distribution ones):
+
+```json
+{ "component": "box|virtues-api|atlas|relay|mac|mobile-shell|mobile-spa|ios",
+  "version": "0.3.0", "sha": "13cfd9c", "channel": "stable|staging|edge",
+  "built_at": "2026-07-19T18:06:00Z",
+  "min_peers": { "box": "0.3.0", "virtues-api": "0.2.0" } }
+```
+
+Concrete first fixes (all cheap, all unblock the rest):
+- **SPA**: emit a version + `minShellVersion` constant at build (the OTA plan already
+  requires this; today `apps/web/package.json` is a placeholder `0.0.1`).
+- **Collector**: actually stamp `gitCommit`/`buildDate` in CI (currently the literal
+  `"unknown"` in `apps/mac-source/Sources/Version.swift`).
+- **Cloud services**: bake SHA/channel the way core does; surface in each `/health`.
+- **Channel becomes first-class** (baked), not inferred from the tag string.
+
+### 1.2 One channel model, fleet-wide
+
+Reuse the box's proven scheme everywhere: `stable` (`v*` / `mac-v*`), `staging.N` /
+`edge` (any `-` identifier → prerelease). Cloud images get **version tags**, not
+`:latest`; the relay pins an `iroh-relay` version instead of `^1`.
+
+### 1.3 The fleet release manifest (the keystone)
+
+A single signed JSON, published per fleet release, that pins every component and
+declares the matrix. This is the artifact that does not exist today.
+
+```json
+{ "release": "0.3.0", "channel": "stable", "cut_at": "…",
+  "components": {
+    "box":         { "tag": "v0.3.0",       "sha": "…" },
+    "virtues-api": { "image": "…@sha256:…", "tag": "v0.3.0" },
+    "atlas":       { "image": "…@sha256:…", "tag": "v0.3.0" },
+    "relay":       { "iroh_relay": "1.4.2" },
+    "mac":         { "tag": "mac-v1.1.0" },
+    "mobile-shell":{ "tag": "ios-v1.1.0", "spa_min": "0.3.0" },
+    "mobile-spa":  { "tag": "spa-v0.3.0", "min_shell": "1.1.0" },
+    "models":      { "tag": "models-2" } },
+  "compat": { /* the lattice — see Part 2 */ } }
+```
+
+Published to a well-known URL (GH Release `fleet-latest`, like `mac-latest`). Every
+node's updater reads *its own row*; the box's model-set drift check already reads a
+model tag this way. Cloud deploy pins from `components.*.image` by digest, giving the
+rollback target the cloud lacks today.
+
+### 1.4 Per-spoke delivery work
+
+- **Box** — implement the 5 pillars (`update-paradigm.md`), reference node. Highest
+  value: Pillar 2 preflight + Pillar 3 atomic release slots.
+- **Cloud** — collapse GHCR-vs-ECR to **one** registry; tag images by version + pin
+  by digest; a real deploy action that SSM-runs `pull <pinned> && restart`; either
+  implement the missing `set-version` endpoint or delete the dead hook; rollback =
+  redeploy prior digest. Build atlas in CI (today: laptop-only).
+- **Relay** — commit the *actually-deployed* unit to git (reconcile
+  `virtues-iroh-relay.service` vs the live `iroh-relay.service`); pin the version; a
+  one-line deploy script.
+- **Mac** — keep the Tauri updater; add an **edge feed** so the test channel updates;
+  reconcile bundled sidecars by **version**, not byte-diff.
+- **Mobile SPA** — build the parked OTA plan (`mobile-spa-ota-plan.md`): two-layer
+  resolver, `minShellVersion` gate, rollback beacon, over iroh loopback. This is the
+  mobile fast-path; native shell rides the App Store.
+- **iOS** — **decide the one codebase** (native `apps/ios` vs Tauri mobile) and add CI
+  (fastlane → TestFlight). Manual Archive is the current single point of failure.
+- **Models** — reference the model tag from the fleet manifest so a release declares
+  its expected model set (box already detects drift, just isn't fed a target).
+
+## Part 2 — The lattice
+
+The edges where non-atomic components meet, and the contract each must carry.
+
+| Edge | Today | Target |
+|------|-------|--------|
+| mobile/iOS → box (iroh HTTP) | one-way `min_ios_version` in `/health` | bidirectional `min_peer` handshake |
+| SPA → box | nothing | `min_box` / `min_spa` check on load |
+| desktop helper → box | nothing | same handshake |
+| box → atlas / virtues-api | auth/telemetry headers only | `min_box` gate + capability flags |
+| box binary ↔ DB migrations | guard **off** at boot | preflight refusal (Pillar 2) |
+| app ↔ SPA bundle | — | `minShellVersion` (OTA plan) |
+| box ↔ sidecars/models | topology + model-drift | version-stamped reconcile |
+
+### 2.1 Version the transport, not just the payload
+
+The iroh ALPN `virtues/http/1` is a single monotonic string with no negotiation —
+a wire break fails opaquely at QUIC. Add an **in-band hello frame** right after
+connect: each side sends its `BUILD` identity + `min_peer`; either side may refuse
+with a *typed* reason ("box 0.3 requires app ≥ 1.1") instead of a dead socket. Keep
+the ALPN as the coarse gate; the hello frame carries the range.
+
+### 2.2 Make the min-version gate bidirectional and universal
+
+Generalize `min_ios_version` → a `min_peers` map in `/health` and the hello frame,
+consumed by **every** client (SPA + desktop today honor nothing), and add the reverse
+`min_box_version` so a client can refuse a too-old box. Replace the naive
+dotted-integer `compareVersions` with real semver (pre-release aware).
+
+### 2.3 Resolve the migration-lineage contradiction
+
+Pillar 2 says *refuse on divergence*; the runtime says `set_ignore_missing(true)`.
+Resolve deliberately:
+- Keep `ignore_missing` for the **dev multi-branch boot** convenience it was added for.
+- Add the explicit `virtues migrate --check` **preflight** in the *upgrade* path
+  (applies nothing, exits non-zero with the precise lineage reason) — this is where
+  the invariant belongs, per the paradigm doc.
+- Derive `KNOWN_MAX_MIGRATION` from the embedded migration set instead of the
+  hardcoded `9` (`restore.rs:159`) so restore and preflight can't silently drift.
+
+### 2.4 Declare the matrix in the manifest
+
+The `compat` block of the fleet manifest is the single source of truth for every
+`min_peer` value; nodes read it rather than hardcoding. This is what lets a release
+say "0.3 box needs 0.2+ api but 1.1+ app" in one reviewed place.
+
+## Phasing
+
+1. **Identity spine** — `BUILD` manifest + version/SHA/channel baked into *every*
+   artifact; surface in `/health`. Cheap, unblocks all of it.
+2. **Box 5 pillars** — per `update-paradigm.md` order (preflight + slots first).
+3. **Lattice core** — hello-frame handshake, bidirectional `min_peers`, fix the
+   migration preflight + `KNOWN_MAX` drift.
+4. **Cloud discipline** — one registry, digest-pinned deploy action, rollback.
+5. **Fleet release manifest** — the keystone; ties nodes + `compat` together.
+6. **Mobile** — SPA OTA (build the parked plan) + iOS CI/TestFlight + pick one iOS
+   codebase.
+7. **Relay hygiene** — unit-in-git = unit-on-host, pinned version, deploy script.
+
+Steps 1 and (per-node) 4/7 can proceed in parallel once the manifest shape is fixed;
+the lattice (3) depends on the identity spine (1).
+
+## Open decisions
+
+- **iOS codebase**: native `apps/ios` (@1.1, honors `min_ios_version`) vs Tauri
+  mobile (@1.0.15) — which one ships? The manifold can't stamp an ambiguous node.
+- **Cloud registry**: GHCR (CI today) or ECR (make/docs today) as the single one?
+- **Manifest signing**: reuse the mac minisign key, or a dedicated fleet key?
+- **Cloud deploy trigger**: does a `v*` fleet tag auto-roll the cloud, or stay
+  operator-gated (blast radius)?
+- **Auto-update posture**: box is deliberately opt-in today — does the manifold keep
+  every node pull-only, or introduce atlas-scheduled windows (the `system_update.rs`
+  comment already claims this, unbuilt)?

--- a/docs/update-model.md
+++ b/docs/update-model.md
@@ -1,0 +1,101 @@
+# The fleet update model (north star)
+
+How a solo dev keeps a growing pile of apps versioned and in-control without
+drowning. One mental model; every new app slots into it. The detailed specs
+([update-manifold-plan.md](update-manifold-plan.md),
+[update-identity-spine.md](update-identity-spine.md)) *implement* this — read
+this first.
+
+## The one idea
+
+> **A thin native shell you ship rarely + a fast web payload you push freely,
+> with a version contract between them.** Maximize the surface you can update on
+> your own; shrink the surface a store gates. Push complexity into the tier you
+> control — the box is the escape hatch for everything else.
+
+Tauri is what makes this possible: one `apps/web` codebase becomes the mac
+desktop app and the (future) mobile shell. Lean on it.
+
+## Two layers, per client
+
+| Layer | What | Changes | Ships via |
+|-------|------|---------|-----------|
+| **Native shell** | Tauri Rust + platform bits (permissions, plugins) | *rarely* | store / notarization |
+| **Web payload** | `apps/web` SPA — ~all product logic | *constantly* | box-serve / OTA |
+
+Keep the shell dumb and stable → 95% of changes never touch a store: one
+codebase, one version, push anytime.
+
+## Three tiers, by update mechanism (not by app)
+
+| Tier | How you ship | Version = | Rollback |
+|------|--------------|-----------|----------|
+| **Continuous** | you push anytime — git tag, box-serve, OTA, self-hosted updater feed | git tag | redeploy prior tag |
+| **Store-gated native** | store review / notarization, own cadence, needs signing | store version | new submission |
+| **Manual infra** | ssh, rarely | pinned | ssh |
+
+## Where each thing lands
+
+| App / artifact | Tier | Notes |
+|----------------|------|-------|
+| Box (`virtues` + sidecars) | Continuous | `virtues.com/sh` + `virtues upgrade` |
+| Cloud (atlas / api / oauth-proxy) | Continuous | image tag + redeploy |
+| Web SPA (desktop **and** mobile payload) | Continuous | box-serve / OTA — the fast layer |
+| **Mac desktop shell** | Continuous-ish | **your own Tauri updater feed, not the Mac App Store** — you control releases, no review |
+| **iOS Tauri shell** (future) | Store-gated | App Store — but its web payload rides OTA |
+| **Native iOS collector** (`apps/ios`) | Store-gated | the one genuine exception (below) |
+| mac collector / desktop-client | rides the mac shell | bundled in the DMG |
+| Relay | Manual infra | ssh + pinned version |
+
+**The liberating fact:** the *only* hard store gate in the whole fleet is **iOS
+App Store**. Mac ships through your own updater feed; everything else you push.
+So "store-gated native" is essentially just iOS.
+
+## The iOS exception
+
+Two separate iOS things — don't conflate them:
+
+- **Tauri mobile shell (future)** — fits the model. Apple *allows* OTA-updating
+  **web content** in a webview (guideline 3.3.2 — same basis as Capacitor Live
+  Updates / CodePush / Expo). So the SPA payload updates OTA; only **native shell
+  or new-capability** changes need a store release. `minShellVersion` is the gate
+  between the two.
+- **Native collector (`apps/ios`)** — *not* Tauri and can't be (24/7 background
+  HealthKit/location/audio can't run in a webview). Stays native, store-gated.
+  Fine, because it changes rarely — **keep it a dumb sensor pipe; move logic into
+  the box** so it almost never ships.
+
+**What's OTA-able:** the UI/web payload, everywhere (desktop + mobile).
+**What's not:** the native collector, and any native-shell / new-capability change.
+
+## The one contract
+
+You don't unify *delivery* — each tier keeps its native transport. You unify:
+
+1. **Identity** — every artifact reports `{version, sha, channel}` the same way
+   (the identity spine). You can always answer "what's running where."
+2. **A compatibility floor** — one min-version check at the one edge that matters
+   (**app ↔ box**), plus `minShellVersion` for the web-payload↔shell edge.
+
+That's the whole discipline. Everything else is per-tier native mechanism.
+
+## Solo-dev rules of thumb
+
+- **Web-first.** New feature? Put it in `apps/web`. It ships everywhere, free.
+- **Keep native shells thin & stable.** Touch them only for permissions, plugins,
+  Tauri bumps — the things that *require* a store release anyway.
+- **Keep the collector dumb.** Every bit of logic you push into the box is a bit
+  you can fix without an App Store round-trip.
+- **Automate only the iOS build.** `fastlane → TestFlight` (build/sign/upload) is
+  worth ~a day; automating metadata/screenshots/review-submission is not. You need
+  exactly **one** native pipeline — it serves the collector now and the Tauri iOS
+  shell later.
+- **The box is the escape hatch.** It can tell an old client "you're too old,
+  here's what to do" — so a stale store app is never a dead end.
+
+## What to build, in leverage order
+
+1. **SPA-OTA** — so the web layer actually updates freely on mobile (turns the
+   whole model on). Spec: `mobile-spa-ota-plan.md`.
+2. **One `fastlane → TestFlight` lane** — the only native pipeline worth having.
+3. **Keep shrinking the collector into the box.**

--- a/virtues-core/src/api/devices.rs
+++ b/virtues-core/src/api/devices.rs
@@ -35,15 +35,25 @@ pub struct DeviceListItem {
     pub paired_at: DateTime<Utc>,
     pub last_seen_at: Option<DateTime<Utc>>,
     pub paired_from_ip: Option<String>,
+    /// The client's reported build identity (from the `X-Virtues-Client`
+    /// header, stored under `device_info.build`). Null until the device has
+    /// made a request on a build that sends it.
+    pub version: Option<String>,
+    pub sha: Option<String>,
+    pub channel: Option<String>,
     /// True if this is the device currently making the request.
     pub is_current: bool,
 }
 
 /// `GET /api/devices` — list all active paired devices for the current user.
 pub async fn list_handler(State(pool): State<PgPool>, user: AuthUser) -> impl IntoResponse {
-    let rows: Result<Vec<(String, String, String, DateTime<Utc>, Option<DateTime<Utc>>, Option<String>)>, _> =
+    #[allow(clippy::type_complexity)]
+    let rows: Result<Vec<(String, String, String, DateTime<Utc>, Option<DateTime<Utc>>, Option<String>, Option<String>, Option<String>, Option<String>)>, _> =
         sqlx::query_as(
-            "SELECT id, kind, label, paired_at, last_seen_at, paired_from_ip \
+            "SELECT id, kind, label, paired_at, last_seen_at, paired_from_ip, \
+                    device_info->'build'->>'version' AS version, \
+                    device_info->'build'->>'sha'     AS sha, \
+                    device_info->'build'->>'channel' AS channel \
              FROM app_device \
              WHERE user_id = $1 AND revoked_at IS NULL \
              ORDER BY last_seen_at DESC NULLS LAST, paired_at DESC",
@@ -56,7 +66,7 @@ pub async fn list_handler(State(pool): State<PgPool>, user: AuthUser) -> impl In
         Ok(rows) => {
             let items: Vec<DeviceListItem> = rows
                 .into_iter()
-                .map(|(id, kind, label, paired_at, last_seen_at, ip)| {
+                .map(|(id, kind, label, paired_at, last_seen_at, ip, version, sha, channel)| {
                     let is_current = id == user.device_id;
                     DeviceListItem {
                         id,
@@ -65,6 +75,9 @@ pub async fn list_handler(State(pool): State<PgPool>, user: AuthUser) -> impl In
                         paired_at,
                         last_seen_at,
                         paired_from_ip: ip,
+                        version,
+                        sha,
+                        channel,
                         is_current,
                     }
                 })

--- a/virtues-core/src/codename.rs
+++ b/virtues-core/src/codename.rs
@@ -67,13 +67,41 @@ pub fn long_version() -> String {
     let sha = env!("GIT_COMMIT");
     let short = &sha[..sha.len().min(7)];
     let date = env!("BUILD_TIME").split('T').next().unwrap_or(env!("BUILD_TIME"));
+    format!("{} \"{}\" · {} · {}", version(), codename(sha), date, short)
+}
+
+/// The clean version string — the full release tag (`GIT_DESCRIBE`, e.g.
+/// `v0.2.0` or `v0.1.0-staging.57`), falling back to the crate semver for
+/// tag-less local builds. Baked at build time. This is the single source of
+/// truth for the version everywhere (`--version`, `/health`, pairing), so a box
+/// never reports the bare `CARGO_PKG_VERSION` (`0.1.0`) when it's on a real tag.
+pub fn version() -> &'static str {
     let describe = env!("GIT_DESCRIBE");
-    let version = if describe.is_empty() {
+    if describe.is_empty() {
         env!("CARGO_PKG_VERSION")
     } else {
         describe
-    };
-    format!("{} \"{}\" · {} · {}", version, codename(sha), date, short)
+    }
+}
+
+/// The release channel, derived from the baked build tag — first-class so every
+/// surface reports the same word. `stable` = a bare `vX.Y.Z` tag (what
+/// virtues.com/sh serves); `staging`/`edge` = the prerelease tracks; `dev` = an
+/// untagged working build (`git describe` with an offset, `-dirty`, or nothing).
+pub fn channel() -> &'static str {
+    let d = env!("GIT_DESCRIBE");
+    if d.is_empty() {
+        "dev"
+    } else if d.contains("staging") {
+        "staging"
+    } else if d.starts_with("edge") {
+        "edge"
+    } else if d.contains('-') {
+        // e.g. `v0.2.0-4-gabc123` or `v0.2.0-dirty` — a build between/after tags.
+        "dev"
+    } else {
+        "stable"
+    }
 }
 
 /// Deterministic `adjective-animal` from a git short sha (or any hex string).

--- a/virtues-core/src/middleware/auth.rs
+++ b/virtues-core/src/middleware/auth.rs
@@ -97,6 +97,12 @@ where
         if let Some(peer) = parts.extensions.get::<virtues_iroh::ProvenPeer>() {
             let node_id = peer.0.to_string();
             if let Some(user) = validate_iroh_peer(&pool, &node_id).await {
+                // Best-effort: refresh the device's reported build identity from
+                // the X-Virtues-Client header (update-manifold Phase 1). Never
+                // affects auth — a missing/malformed header is simply skipped.
+                if let Some(cb) = parse_client_header(&parts.headers) {
+                    record_client_build(&pool, &user.device_id, &cb).await;
+                }
                 return Ok(user);
             }
         }
@@ -176,6 +182,56 @@ pub(crate) async fn validate_iroh_peer(pool: &PgPool, node_id: &str) -> Option<A
         device_id,
         device_label,
     })
+}
+
+/// The build identity a client reports via
+/// `X-Virtues-Client: version=…; sha=…; channel=…`. All best-effort — a
+/// malformed header is ignored, never a request failure.
+#[derive(Debug, Default)]
+pub(crate) struct ClientBuild {
+    pub version: String,
+    pub sha: String,
+    pub channel: String,
+}
+
+/// Parse the `X-Virtues-Client` header. Returns `None` unless a version is
+/// present (so we never write an empty build blob) and the values are within
+/// sane length bounds (hygiene against a hostile paired client).
+pub(crate) fn parse_client_header(headers: &axum::http::HeaderMap) -> Option<ClientBuild> {
+    let raw = headers.get("x-virtues-client")?.to_str().ok()?;
+    let mut cb = ClientBuild::default();
+    for part in raw.split(';') {
+        let mut kv = part.splitn(2, '=');
+        match (kv.next().map(str::trim), kv.next().map(str::trim)) {
+            (Some("version"), Some(v)) => cb.version = v.to_string(),
+            (Some("sha"), Some(v)) => cb.sha = v.to_string(),
+            (Some("channel"), Some(v)) => cb.channel = v.to_string(),
+            _ => {}
+        }
+    }
+    if cb.version.is_empty() || cb.version.len() > 64 || cb.sha.len() > 64 || cb.channel.len() > 32
+    {
+        return None;
+    }
+    Some(cb)
+}
+
+/// Merge a client's reported build into `device_info.build`. Best-effort — a
+/// failure never blocks the request. The shallow jsonb `||` replaces just the
+/// `build` key, so this is an idempotent refresh.
+pub(crate) async fn record_client_build(pool: &PgPool, device_id: &str, cb: &ClientBuild) {
+    let _ = sqlx::query(
+        "UPDATE app_device \
+         SET device_info = device_info || jsonb_build_object(\
+             'build', jsonb_build_object('version', $2::text, 'sha', $3::text, 'channel', $4::text)) \
+         WHERE id = $1",
+    )
+    .bind(device_id)
+    .bind(&cb.version)
+    .bind(&cb.sha)
+    .bind(&cb.channel)
+    .execute(pool)
+    .await;
 }
 
 /// Idempotent upsert for the synthetic console device row. Called at server

--- a/virtues-core/src/middleware/auth.rs
+++ b/virtues-core/src/middleware/auth.rs
@@ -218,13 +218,15 @@ pub(crate) fn parse_client_header(headers: &axum::http::HeaderMap) -> Option<Cli
 
 /// Merge a client's reported build into `device_info.build`. Best-effort — a
 /// failure never blocks the request. The shallow jsonb `||` replaces just the
-/// `build` key, so this is an idempotent refresh.
+/// `build` key. The `IS DISTINCT FROM` guard makes this a no-op write on the
+/// common path (build unchanged between upgrades), so it doesn't churn the row
+/// on every request — it only writes when the reported sha actually changes.
 pub(crate) async fn record_client_build(pool: &PgPool, device_id: &str, cb: &ClientBuild) {
     let _ = sqlx::query(
         "UPDATE app_device \
          SET device_info = device_info || jsonb_build_object(\
              'build', jsonb_build_object('version', $2::text, 'sha', $3::text, 'channel', $4::text)) \
-         WHERE id = $1",
+         WHERE id = $1 AND (device_info->'build'->>'sha') IS DISTINCT FROM $3::text",
     )
     .bind(device_id)
     .bind(&cb.version)

--- a/virtues-core/src/server/mod.rs
+++ b/virtues-core/src/server/mod.rs
@@ -949,7 +949,8 @@ async fn health(axum::extract::State(state): axum::extract::State<AppState>) -> 
         status_code,
         Json(serde_json::json!({
             "status": if is_healthy { "healthy" } else { "unhealthy" },
-            "version": env!("CARGO_PKG_VERSION"),
+            "version": crate::codename::version(),
+            "channel": crate::codename::channel(),
             "commit": env!("GIT_COMMIT"),
             "built_at": env!("BUILD_TIME"),
             "min_ios_version": min_ios_version,


### PR DESCRIPTION
First slice of the 0.3 update-manifold work: every artifact states its identity, clients report it to the box, and the Devices page shows the fleet at a glance.

## Docs (the strategy)
- **docs/update-model.md** — the north star: thin native shell + fast web payload, three tiers (continuous / store-gated / manual infra), the iOS exception, solo-dev rules.
- **docs/update-manifold-plan.md** — the full manifold + compatibility-lattice design, grounded in a 9-node fleet audit.
- **docs/update-identity-spine.md** — this phase's spec.

## Code (the identity spine)
- **Box**: first-class `codename::version()` + `channel()` (stable/staging/edge/dev from the baked tag). `/health` now reports the real version + channel — was the bare `CARGO_PKG_VERSION` (`0.1.0`), disagreeing with `--version`.
- **SPA**: `$lib/build.ts` bakes `{version, sha, channel}` (extends the existing `__BUILD_COMMIT__`); a one-time global fetch interceptor stamps `X-Virtues-Client` on box requests. CI now passes `GIT_COMMIT`/`GIT_DESCRIBE` into the web build.
- **Box ← clients**: the auth extractor records the header into `device_info.build` (best-effort, never affects auth; only writes when the sha changes). `/api/devices` surfaces `version/sha/channel`; **DevicesView shows `version · sha · channel · last seen` per device**. No migration — `device_info` jsonb already existed for this.
- **Native iOS**: stamps the header at the `HTTPWire.serialize` chokepoint (every BoxTransport request).
- **Mac collector**: `release-mac.yml` stamps real version/date/sha into `Version.swift` (kills the hardcoded `"unknown"`).
- Hygiene: untrack `.claude/` runtime lock.

Display-only by design — the supported/update-required verdict is the Phase-3 hook (bidirectional min-version). Cloud identity deferred to Phase 4 per discussion.

## Verified
`cargo check` clean · `svelte-check` 0 errors · `pnpm build` OK with header baked into the bundle. iOS/collector changes need a real Xcode/CI build (no iOS CI yet — that's Phase 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)