### PR TITLE
Box safety: atomic release slots, migration preflight, rollback

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -301,8 +301,17 @@ jobs:
             TAR_EXTRA="virtues-qnnd"
           fi
 
+          # BUILD.json — the tarball's build identity. `virtues upgrade` reads
+          # it for SHA-based no-op detection (the only honest identity for
+          # prerelease builds, which all report the bare crate version) and to
+          # name the release slot (<tag>-<sha7>).
+          printf '{"version":"%s","sha":"%s","channel":"%s","built_at":"%s"}\n' \
+            "${{ steps.tag.outputs.version }}" "${GITHUB_SHA}" \
+            "$(case "${{ steps.tag.outputs.version }}" in *staging*) echo staging;; edge*) echo edge;; v*-*) echo dev;; v*) echo stable;; *) echo dev;; esac)" \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > staging/BUILD.json
+
           TAR_NAME="virtues-${{ steps.tag.outputs.version }}-${{ matrix.arch }}-linux.tar.gz"
-          tar -czf "dist/${TAR_NAME}" -C staging virtues llama-server web actions actions-bin $TAR_EXTRA
+          tar -czf "dist/${TAR_NAME}" -C staging virtues llama-server web actions actions-bin BUILD.json $TAR_EXTRA
           (cd dist && sha256sum "${TAR_NAME}" > "${TAR_NAME}.sha256")
 
           # The installer ships as a standalone binary (NOT inside the

--- a/crates/virtues-registry/src/tools.rs
+++ b/crates/virtues-registry/src/tools.rs
@@ -878,34 +878,34 @@ fn setup_action_tool() -> ToolConfig {
         id: "setup_action".to_string(),
         name: "Setup Action".to_string(),
         description: "Create a scheduled action".to_string(),
-        llm_description: r#"Turn the current chat into an action that runs on a schedule or as an API endpoint.
+        llm_description: r#"Turn the current chat's intent into a saved action that runs on a schedule, on demand, or via a triggerable endpoint.
 
 Use this tool when:
-- User asks to set up a recurring task (e.g. "check Hacker News every hour")
-- User wants an automated action that runs periodically
-- User wants to create a webhook/endpoint that triggers an AI task
+- User asks to set up a recurring task (e.g. "check Hacker News every hour", "write my examen at 6am")
+- User wants an automated action that runs periodically or a one-off future task
+- User wants a standing task they can trigger via API/webhook
 
 Parameters:
-- name: Short descriptive name for the action (e.g. "HN Highlights")
-- instruction: What the action should do each time it runs. Be specific and detailed.
+- name: Short descriptive name for the action (e.g. "HN Highlights"). One action per name per chat — reusing a name updates that action; a new name creates another alongside it.
+- agent: What the action should do each time it runs. Be specific and detailed.
 - cron_schedule: Cron expression for when to run (6-field: sec min hour day month dow). Schedules run in the user's LOCAL timezone, so write the hour the user means literally (no UTC conversion). Examples:
   - "0 0 * * * *" = every hour
   - "0 0 9 * * *" = daily at 9am local time
   - "0 */30 * * * *" = every 30 minutes
   - "0 0 9 * * 1-5" = weekday mornings at 9am local time
-- endpoint: Set to true to also expose as a triggerable API endpoint
-- activation_code: Optional Python code that runs before each invocation (e.g. to fetch data). The code is dry-run tested before saving.
+- triggers: Optional array of allowed invocation sources: "cron", "manual", "tool", "api", "webhook". Defaults to ["cron","manual","tool"] when cron_schedule is set, otherwise ["manual","tool"]. Include "api" or "webhook" to expose the action as a triggerable endpoint.
+- condition: Optional SQL boolean expression evaluated before each run; the run is skipped when it is false. Power-user gate — omit unless the user explicitly asks for one.
 
 The action will post its results back into this chat each time it runs."#.to_string(),
         parameters: serde_json::json!({
             "type": "object",
-            "required": ["name", "instruction"],
+            "required": ["name", "agent"],
             "properties": {
                 "name": {
                     "type": "string",
-                    "description": "Short name for the action (e.g. 'HN Highlights', 'Daily Digest')"
+                    "description": "Short name for the action (e.g. 'HN Highlights', 'Daily Digest'). Reusing a name in this chat updates that action; a new name creates another."
                 },
-                "instruction": {
+                "agent": {
                     "type": "string",
                     "description": "Detailed instruction for what the action should do each run"
                 },
@@ -913,14 +913,17 @@ The action will post its results back into this chat each time it runs."#.to_str
                     "type": "string",
                     "description": "Cron schedule (6-field: sec min hour day month dow). E.g. '0 0 * * * *' for hourly"
                 },
-                "endpoint": {
-                    "type": "boolean",
-                    "description": "Whether to also expose as a triggerable API endpoint",
-                    "default": false
+                "triggers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["cron", "manual", "tool", "api", "webhook"]
+                    },
+                    "description": "Allowed invocation sources. Defaults based on cron_schedule; add 'api'/'webhook' to expose as an endpoint."
                 },
-                "activation_code": {
+                "condition": {
                     "type": "string",
-                    "description": "Optional Python code to run before each invocation (e.g. fetch external data)"
+                    "description": "Optional SQL boolean expression gating each run (run skipped when false)"
                 }
             }
         }),

--- a/docs/applets-overhaul-plan.md
+++ b/docs/applets-overhaul-plan.md
@@ -35,8 +35,40 @@ Applet = a **typed Rust enum of archetypes**, each a small serde spec, validated
 ## Decisions locked
 
 - **Name: `Applet`** — one word, unit and thing. No two-tier "automations vs artifacts" split (that re-drew a line the schema erased). No separate word for the collection. `action`/`app_actions` stays as the internal/code word; **Applet** is the user-facing noun everywhere.
+  - **Re-litigated and re-confirmed 2026-07-19.** The namespace is picked over (IFTTT: Applets; Claude: Artifacts; Alexa: Skills + Routines; Apple: Shortcuts; HA: Automations). Rejected: **Artifact** (denotes inert output, not a thing that runs), **Instruments** (best semantic coverage — means-of-action + instrument-panel + document-that-enacts, plus the Rule of St. Benedict ch. 4 "Instruments of Good Works" lineage — but too long), **Practices** (see below), **Daemons** (techy, demons), agent-nouns like Keeper/Steward/Familiar (personhood fails for dashboards). Persona-panel finding: engineers name the mechanism (jobs/workers/units), contemplatives name the meaning (practices/offices/a rule), laypeople name only the *instance* ("the calorie thing") — no word wins all three camps, so the category noun just has to be unembarrassing in the nav. Applet wins by offending no one.
+  - **"Practices" survives as a collection, not the primitive:** the contemplative built-ins (examen, daily office, weekly review) are marketed in the gallery/starter surface as **Practices** — a curated set of applets. Honest to both the monastery and the meditation app; never a schema concept.
+  - Feature-level vocabulary reserved the same way: **vigil** is available as the friendly word for a watcher/trigger-shaped applet in UI copy, never a type.
 - **One primitive, one flat list**, sectioned only by `owner` → **"Yours" / "Built-in."** That's a filter, not a taxonomy of kinds.
 - **`runtime` stops being a type the user picks.** It collapses into two orthogonal *properties* every applet may have: does it do **background work** (scheduled / persistent / triggered) and does it have a **face** (UI). Zero, one, or both. `function` vs `service` is just a lifecycle knob; `view` is just "has a face."
+
+## Product layer (decided 2026-07-19)
+
+A second round of decisions, made from the user's side of the glass:
+
+- **Chat is the front door; authoring and adopting are the same primitive.** The core loop is conversational intent → applet: "remind me to X on date Y," "build a dashboard of heart rate vs. workouts," "a calorie app — I send a photo, it logs," "each morning before 6am, write my examen from my narrative identity + Catholic values + yesterday's data." The ~5% power-author (git-link, terminal) is the *same* primitive with the hood open — one paradigm serves both; no separate builder surface, no catalog-first bet.
+- **Lifecycle is a first-class property: `ephemeral` vs `persistent`.** A dated reminder is an applet that archives itself on completion (disable/archive-on-run); an examen runs forever. The AI infers lifecycle from intent; it's visible and flippable on the detail page. This kills the "applet graveyard" problem structurally — one-offs clean themselves up, so the list only holds living things.
+- **Owner grows a third value: `system | user | ai`.** Honest framing: applets are the box's **universal scheduler and job system**. The list default-hides `system` rows (a filter, not a wall) — `embedding_index` and `credential_refresh` are inspectable on demand because transparency is the brand, but they don't crowd the addiction-fighter's guardian out of view.
+- **Failure UX v1 = what exists + a "needs attention" strip.** Errors keep surfacing in the list's last-run status; add one strip at the top of the applets surface (and its homepage tile) for errored / hasn't-run-when-expected / credential-expired. No new alerting infrastructure in v1.
+- **Last-mile delivery is v2.** Pings/notifications route through `virtues-helpers` primitives so every applet gets them for free when they land; v2 is messaging-shaped (iMessage/text), not APNs-first. Do not design around APNs now.
+- **Explicitly out of scope by decision:** persona counterparty ethics and addiction-recovery duty-of-care framing (not product questions for now); sharing/app-store distribution (v2); output-surface strategy beyond today's chat/pages (v2, arrives with messaging).
+
+## Caps — per-applet limits (v1, a real differentiator)
+
+Researched the two closest personal-agent projects (2026-07): **neither enforces anything.**
+
+- **OpenClaw**: token counting, cost estimation, and context-size caps (`toolResultMaxChars` etc.) — observability only. The feature request for `maxTokensPerDay`-style budgets ([#58826](https://github.com/openclaw/openclaw/issues/58826)) was closed *not planned*; official guidance is "set a hard cap at your LLM provider." Sandbox = isolation, not metering.
+- **Hermes Agent**: no app-layer limits; documents four "spending lanes" (primary / auxiliary / gateway / background) for *diagnosing* spend, recommends cheaper models for background jobs, defers hard limits to provider spending caps. No RAM/storage limits.
+
+Both punt to the provider because they don't own one. **Virtues owns both the provider and the runtime**, so caps can be native and hard:
+
+| Limit | Enforced where | Mechanism |
+|---|---|---|
+| `max_llm_cost` (per-run + per-day) | Gateway/wallet | Inference already flows through the virtues-api ledger; tag calls with `action_id`, hard-stop at the cap, surface in needs-attention. Extends the existing per-call/day/month cap family. |
+| `max_ram`, `cpu`, `timeout` | Runtime | The `systemd-run` jail already used for `code_interpreter` (`MemoryMax`, `CPUQuota`, `RuntimeMaxSec`) — same profile, now parameterized per applet. |
+| `max_storage` | Runtime | Quota on the applet's state/working dir. |
+| `max_runs` (per hour/day) | Scheduler | Backstop against trigger storms — mandatory before event/data triggers (thread 7) light up composition loops. |
+
+Defaults come from the archetype (a Reflect applet gets a daily LLM budget; a View gets none); overridable in a manifest `limits` block and on the detail page. The **plan/preview gate shows estimated recurring cost** ("~$0.12/day") next to the capability grants — cost is a capability. Scheduled/background applets default to the cheaper slot per the slot doctrine (Chat/Lite, no model literals), echoing the one piece of Hermes guidance worth keeping.
 
 ## The model
 
@@ -45,7 +77,9 @@ Applet = a **typed Rust enum of archetypes**, each a small serde spec, validated
 | **Applet** | A thing that runs for you. Folder at `actions/<name>/` (manifest + optional code/face). |
 | **Background work** | Optional. Cron / persistent service / trigger-driven. (subsumes today's `function` + `service`) |
 | **Face** | Optional. A rendered UI. (subsumes today's `view`) |
-| **Owner** | `system` (built-in, reconcile-managed) or `user` (yours). The only sectioning. |
+| **Owner** | `system` (built-in, reconcile-managed), `user` (yours), or `ai` (chat-authored). The only sectioning; list default-hides `system`. |
+| **Lifecycle** | `ephemeral` (archive-on-completion — a dated reminder) or `persistent`. AI infers from intent; flippable in the detail page. |
+| **Limits** | Per-applet caps: `max_llm_cost`, `max_ram`, `max_storage`, `timeout`, `max_runs`. Archetype defaults, manifest-overridable. |
 | **Definition** | On disk (manifest + source). Git-able. |
 | **State** | In Postgres (enabled, schedule, runs, memory). Never on disk. |
 
@@ -136,9 +170,10 @@ Two lanes, because today's import is **one-way and destructive** (`git clone --d
 
 ## Sequence
 
-1. **Rename + collapse the surface** — Applet everywhere; one owner-sectioned list (no sub-tabs); one degrading detail page. Cheap; fixes half the complaints; everything lands on top.
+0. **Immediate fixes (pre-refactor, small)** — `setup_action` contract drift (tool schema advertises `endpoint` + `activation_code`; the executor drops both — either implement or stop advertising) and the one-agent-applet-per-chat id collision (`action_agent_<chat_id>` upsert silently overwrites). These are the current AI-authoring story's credibility.
+1. **Rename + collapse the surface** — Applet everywhere; one owner-sectioned list (no sub-tabs, `system` hidden by default); one degrading detail page; the **needs-attention strip**; `lifecycle` column + archive-on-completion. Cheap; fixes half the complaints; everything lands on top.
 2. **Unlock on-box authoring** — runtime-loadable views + the sandboxed-script path + sandbox routing. This is what makes live AI authoring *possible at all*. Flagship.
-3. **The closed authoring loop** — file-authoring tools scoped to `actions/<name>/`, write→run→see→fix, AGENTS.md + authoring Skills, capability-manifest permissions.
+3. **The closed authoring loop** — file-authoring tools scoped to `actions/<name>/`, write→run→see→fix, AGENTS.md + authoring Skills, capability-manifest permissions, **and the limits block** (caps enforced at gateway + jail; estimated cost shown at the plan/preview gate).
 4. **Event/data triggers + wire the dead chaining** — the composability unlock.
 5. **Git box-owned lane** — commit-back, rollback, reviewable diffs.
 6. **Cleanup** — memory bounding, delete state, trigger/condition vocabulary, doc-drift fix.

--- a/tools/virtues-installer/src/config.rs
+++ b/tools/virtues-installer/src/config.rs
@@ -100,6 +100,12 @@ impl InstallConfig {
         self.install_prefix.join("share/virtues/web")
     }
 
+    /// The slot-layout root (`share/virtues`) — holds `releases/`, the
+    /// `current` flip link, the routing symlinks, and `install.json`.
+    pub fn share_virtues_dir(&self) -> PathBuf {
+        self.install_prefix.join("share/virtues")
+    }
+
     /// Where the action tree (manifests + UI + sources.toml) lands on the box.
     /// virtues-core reads this via `VIRTUES_ACTIONS_DIR` (see
     /// `action_templates::actions_root`); the default here must match

--- a/tools/virtues-installer/src/download.rs
+++ b/tools/virtues-installer/src/download.rs
@@ -1,9 +1,13 @@
-//! Binary tarball download + SHA256 verify + extract.
+//! Binary tarball download + SHA256 verify + extract → atomic release slot.
 //!
 //! Resolves "latest" via the GitHub Releases API when no version is pinned.
 //! SHA-verifies the tarball against the sidecar `.sha256` (CI uploads both).
-//! Extracts to a tempdir, then installs the `virtues` binary to
-//! `$INSTALL_PREFIX/bin/` and `web/` to `$INSTALL_PREFIX/share/virtues/web/`.
+//! Extracts to a tempdir, stages the WHOLE release into
+//! `$INSTALL_PREFIX/share/virtues/releases/<slot>/`, flips the `current`
+//! symlink, and maintains the stable routing links every well-known path
+//! resolves through (see virtues-core `cli/slots.rs` for the layout). The
+//! installer is the ONLY creator of this layout; `virtues upgrade` requires
+//! it and `virtues rollback` flips within it.
 
 use anyhow::{anyhow, Context, Result};
 use sha2::{Digest, Sha256};
@@ -74,94 +78,78 @@ pub async fn download_binary(cfg: &mut InstallConfig, arch: &str) -> Result<()> 
     cmd.args(["-xzf", tar_path.to_str().unwrap(), "-C", tmpdir.path().to_str().unwrap()]);
     run_step(&format!("Extract {tar_name}"), cmd).await?;
 
-    // Install binary (atomic replace — the dst is very likely the running box
-    // binary, so a plain truncating copy would hit ETXTBSY "text file busy").
-    let bin_src = tmpdir.path().join("virtues");
-    let bin_dst = cfg.binary_path();
-    install_executable(&bin_src, &bin_dst)?;
+    // ── Stage the whole release into its slot ──────────────────────────
+    // Slot id comes from the tarball's BUILD.json (<version>-<sha7>); older
+    // tarballs without one get a timestamp suffix.
+    let slot_id = read_slot_id(tmpdir.path(), &version);
+    let share = cfg.share_virtues_dir();
+    let releases = share.join("releases");
+    let slot = releases.join(&slot_id);
+    fs::create_dir_all(&releases).with_context(|| format!("creating {}", releases.display()))?;
+    let _ = fs::remove_dir_all(&slot); // re-install of the same build starts clean
 
-    // llama-server — the inference sidecar engine (embed + rerank; see
-    // install::install_inference). The tarball ships the per-arch build our
-    // CI compiled; on the Dragon image GPU offload comes through the generic
-    // Vulkan/OpenCL backends, so there is no per-board binary swap.
-    let llama_src = tmpdir.path().join("llama-server");
-    if llama_src.is_file() {
-        let llama_dst = cfg.llama_binary_path();
-        install_executable(&llama_src, &llama_dst)?;
-        ui::ok(&format!("Installed llama-server → {}", llama_dst.display()));
+    fs::create_dir_all(&slot)?;
+    // Binaries — exec bits set; only `virtues` is mandatory.
+    install_executable(&tmpdir.path().join("virtues"), &slot.join("virtues"))?;
+    let has_llama = tmpdir.path().join("llama-server").is_file();
+    if has_llama {
+        install_executable(&tmpdir.path().join("llama-server"), &slot.join("llama-server"))?;
     } else {
-        ui::warn(
-            "llama-server not in tarball (pre-v0.1.1 release) — inference sidecars \
-             will not be installed. Upgrade once a newer release is available.",
-        );
+        ui::warn("llama-server not in tarball — inference sidecars unavailable from this release");
     }
-
-    // virtues-qnnd — the Dragon NPU daemon (Hexagon v68). Present only in the
-    // aarch64 tarball built with QNN_SDK_ROOT; absent (or a stub) elsewhere, so
-    // install it only when the real binary shipped. install_qnn checks for it
-    // and errors clearly if a Dragon install finds it missing.
-    let qnnd_src = tmpdir.path().join("virtues-qnnd");
-    if qnnd_src.is_file() {
-        let qnnd_dst = cfg.qnnd_binary_path();
-        install_executable(&qnnd_src, &qnnd_dst)?;
-        ui::ok(&format!("Installed virtues-qnnd → {}", qnnd_dst.display()));
+    let has_qnnd = tmpdir.path().join("virtues-qnnd").is_file();
+    if has_qnnd {
+        install_executable(&tmpdir.path().join("virtues-qnnd"), &slot.join("virtues-qnnd"))?;
     }
-
-    // Install web dir (newer tarballs ship apps/web/build/ as web/).
-    let web_src = tmpdir.path().join("web");
-    if web_src.is_dir() {
-        let web_dst = cfg.web_dir();
-        // Remove any prior copy so we replace cleanly.
-        let _ = fs::remove_dir_all(&web_dst);
-        copy_dir_all(&web_src, &web_dst)?;
-        ui::ok(&format!("Installed web UI → {}", web_dst.display()));
+    if tmpdir.path().join("BUILD.json").is_file() {
+        let _ = fs::copy(tmpdir.path().join("BUILD.json"), slot.join("BUILD.json"));
     }
-
-    // Install the action tree (newer tarballs ship `actions/`). virtues-core
-    // globs this at runtime; without it the box has no actions and pairing
-    // returns an empty action map. Older tarballs lack it — warn, don't fail.
-    let actions_src = tmpdir.path().join("actions");
-    if actions_src.is_dir() {
-        let actions_dst = cfg.actions_dir();
-        let _ = fs::remove_dir_all(&actions_dst);
-        copy_dir_all(&actions_src, &actions_dst)?;
-        ui::ok(&format!("Installed actions → {}", actions_dst.display()));
-    } else {
-        ui::warn(
-            "actions/ not in tarball (pre-v1.x release) — the box will have no \
-             actions and clients will pair with an empty action map. Upgrade to \
-             a release that ships actions/.",
-        );
-    }
-
-    // Install the compiled action binaries (ios_*, *_sync, …). These must be
-    // executable, so they go through install_executable (atomic replace +
-    // chmod 0755) rather than copy_dir_all, which copies bytes without the
-    // exec bit. virtues-core forks them by name via VIRTUES_ACTIONS_BIN_DIR.
-    let actions_bin_src = tmpdir.path().join("actions-bin");
-    if actions_bin_src.is_dir() {
-        let actions_bin_dst = cfg.actions_bin_dir();
-        fs::create_dir_all(&actions_bin_dst)
-            .with_context(|| format!("creating {}", actions_bin_dst.display()))?;
-        let mut count = 0usize;
-        for entry in fs::read_dir(&actions_bin_src)? {
-            let entry = entry?;
-            if entry.file_type()?.is_file() {
-                install_executable(&entry.path(), &actions_bin_dst.join(entry.file_name()))?;
-                count += 1;
+    // Directories.
+    for name in ["web", "actions", "actions-bin"] {
+        let src = tmpdir.path().join(name);
+        if src.is_dir() {
+            if name == "actions-bin" {
+                // Compiled action executables need their exec bits.
+                let dst = slot.join(name);
+                fs::create_dir_all(&dst)?;
+                for entry in fs::read_dir(&src)? {
+                    let entry = entry?;
+                    if entry.file_type()?.is_file() {
+                        install_executable(&entry.path(), &dst.join(entry.file_name()))?;
+                    }
+                }
+            } else {
+                copy_dir_all(&src, &slot.join(name))?;
             }
+        } else {
+            ui::warn(&format!("{name}/ not in tarball — skipped"));
         }
-        ui::ok(&format!(
-            "Installed {count} action binaries → {}",
-            actions_bin_dst.display()
-        ));
-    } else {
-        ui::warn(
-            "actions-bin/ not in tarball (pre-v1.x release) — function actions \
-             (ios_*, syncs) have no executable on the box and their webhooks \
-             will fail. Upgrade to a release that ships actions-bin/.",
-        );
     }
+    ui::ok(&format!("Staged release slot {slot_id}"));
+
+    // ── Activate: flip `current`, maintain the routing symlinks ────────────
+    // Every well-known path is a symlink resolving THROUGH `current`, so env
+    // files and systemd units never change across releases; a flip moves
+    // binary + web + actions together. force_symlink replaces whatever is
+    // there — including the pre-slot real files/dirs of an older install
+    // (this is the one-time layout adoption; unlink works on a running
+    // binary's path, the process keeps its inode until restart).
+    atomic_flip(&share, &slot)?;
+    let current = share.join("current");
+    force_symlink(&current.join("web"), &share.join("web"))?;
+    force_symlink(&current.join("actions"), &share.join("actions"))?;
+    force_symlink(&current.join("virtues"), &cfg.binary_path())?;
+    if has_llama {
+        force_symlink(&current.join("llama-server"), &cfg.llama_binary_path())?;
+    }
+    if has_qnnd {
+        force_symlink(&current.join("virtues-qnnd"), &cfg.qnnd_binary_path())?;
+    }
+    force_symlink(&current.join("actions-bin"), &cfg.actions_bin_dir())?;
+    ui::ok(&format!("Activated {slot_id} (current → releases/{slot_id})"));
+
+    // Keep current + one previous; prune the rest.
+    prune_slots(&share, 1);
 
     cfg.pinned_version = Some(version);
     Ok(())
@@ -337,4 +325,84 @@ fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Slot directory name for this tarball: `<version>-<sha7>` from BUILD.json,
+/// else a timestamp suffix (older tarballs).
+fn read_slot_id(tmpdir: &Path, version: &str) -> String {
+    let sha7 = fs::read(tmpdir.join("BUILD.json"))
+        .ok()
+        .and_then(|b| serde_json::from_slice::<serde_json::Value>(&b).ok())
+        .and_then(|v| v.get("sha").and_then(|s| s.as_str()).map(|s| s[..s.len().min(7)].to_string()));
+    match sha7 {
+        Some(sha) => format!("{version}-{sha}"),
+        None => format!("{version}-{}", chrono_free_timestamp()),
+    }
+}
+
+/// UTC timestamp without pulling chrono into the installer: seconds since
+/// epoch is unique enough for a slot suffix.
+fn chrono_free_timestamp() -> String {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs().to_string())
+        .unwrap_or_else(|_| "0".into())
+}
+
+/// Atomically point `share/current` at `slot` (tmp symlink + rename — rename
+/// on one filesystem is atomic, so `current` always resolves to a complete
+/// release).
+fn atomic_flip(share: &Path, slot: &Path) -> Result<()> {
+    let tmp = share.join(".current.tmp");
+    let _ = fs::remove_file(&tmp);
+    std::os::unix::fs::symlink(slot, &tmp).with_context(|| format!("symlink {}", tmp.display()))?;
+    fs::rename(&tmp, share.join("current")).context("flipping current")?;
+    Ok(())
+}
+
+/// Replace whatever exists at `link` (file, dir, or old symlink) with a
+/// symlink to `target`. The dir case is the one-time adoption of a pre-slot
+/// install, whose web/actions were real directories.
+fn force_symlink(target: &Path, link: &Path) -> Result<()> {
+    if let Some(parent) = link.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    if link.is_symlink() || link.is_file() {
+        let _ = fs::remove_file(link);
+    } else if link.is_dir() {
+        let _ = fs::remove_dir_all(link);
+    }
+    std::os::unix::fs::symlink(target, link)
+        .with_context(|| format!("symlink {} -> {}", link.display(), target.display()))?;
+    Ok(())
+}
+
+/// Delete release slots beyond the newest `keep` (never the one `current`
+/// points at). Best-effort.
+fn prune_slots(share: &Path, keep: usize) {
+    let current = fs::read_link(share.join("current"))
+        .ok()
+        .and_then(|t| if t.is_absolute() { t.canonicalize().ok() } else { share.join(t).canonicalize().ok() });
+    let mut slots: Vec<(std::time::SystemTime, std::path::PathBuf)> =
+        fs::read_dir(share.join("releases"))
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter(|e| e.path().is_dir())
+            .filter_map(|e| {
+                Some((e.metadata().ok()?.modified().ok()?, e.path().canonicalize().ok()?))
+            })
+            .collect();
+    slots.sort_by(|a, b| b.0.cmp(&a.0));
+    let mut kept = 0usize;
+    for (_, slot) in slots {
+        let is_current = current.as_ref().map(|c| c == &slot).unwrap_or(false);
+        if is_current || kept < keep {
+            if !is_current {
+                kept += 1;
+            }
+            continue;
+        }
+        let _ = fs::remove_dir_all(&slot);
+    }
 }

--- a/tools/virtues-installer/src/flow.rs
+++ b/tools/virtues-installer/src/flow.rs
@@ -100,6 +100,7 @@ pub async fn run(cli: Config) -> Result<()> {
             ui::skip("Manual inference — skipping local sidecar provisioning")
         }
     }
+    install::write_install_manifest(&cfg, &inference)?;
     install::write_env_file(&cfg, &inference, validation.as_ref()).await?;
     install::run_bringup(&cfg).await?;
     install::install_systemd_unit(&cfg).await?;

--- a/tools/virtues-installer/src/install.rs
+++ b/tools/virtues-installer/src/install.rs
@@ -1132,3 +1132,29 @@ pub async fn health_check(cfg: &InstallConfig, mode: &InferenceMode) -> Result<u
 
     Ok(issues)
 }
+
+/// Write `install.json` — the box's topology manifest, the single place that
+/// records what shape this install is (which inference profile, which sidecar
+/// units exist, where models live). `virtues upgrade`/`doctor` READ this
+/// instead of sniffing unit files, so what-to-restart is declared, not
+/// guessed (the guessing is what once restarted the wrong sidecars and never
+/// restarted qnnd). Rewritten on every install run — the installer is the
+/// only writer.
+pub fn write_install_manifest(cfg: &InstallConfig, mode: &InferenceMode) -> Result<()> {
+    let (profile, sidecars): (&str, Vec<&str>) = match mode {
+        InferenceMode::Dragon => ("dragon", vec!["virtues-qnnd"]),
+        InferenceMode::Bundled => ("bundled", vec!["virtues-embed", "virtues-rerank"]),
+        InferenceMode::Manual { .. } => ("manual", vec![]),
+    };
+    let manifest = serde_json::json!({
+        "profile": profile,
+        "sidecars": sidecars,
+        "models_dir": cfg.models_dir(),
+        "written_by": env!("CARGO_PKG_VERSION"),
+    });
+    let path = cfg.share_virtues_dir().join("install.json");
+    fs::write(&path, serde_json::to_vec_pretty(&manifest).expect("manifest serializes"))
+        .with_context(|| format!("writing {}", path.display()))?;
+    ui::ok(&format!("Wrote topology manifest → {}", path.display()));
+    Ok(())
+}

--- a/virtues-core/src/cli/mod.rs
+++ b/virtues-core/src/cli/mod.rs
@@ -11,6 +11,7 @@ pub mod reindex;
 pub mod report_crash;
 pub mod reset;
 pub mod restore;
+pub mod slots;
 pub mod types;
 pub mod ui;
 pub mod uninstall;
@@ -61,6 +62,11 @@ pub async fn run(cli: Cli, virtues: Virtues) -> Result<(), Box<dyn std::error::E
             // Same — and intentionally does NOT touch the DB; the new
             // binary's `migrate` does that after the binary swap.
             unreachable!("Upgrade command should be handled in main.rs");
+        }
+
+        Commands::Rollback => {
+            // Same — a pure slot flip + service restart, no DB.
+            unreachable!("Rollback command should be handled in main.rs");
         }
 
         Commands::Uninstall { .. } => {

--- a/virtues-core/src/cli/mod.rs
+++ b/virtues-core/src/cli/mod.rs
@@ -92,10 +92,50 @@ pub async fn run(cli: Cli, virtues: Virtues) -> Result<(), Box<dyn std::error::E
             unreachable!("LakeAdopt command should be handled in main.rs");
         }
 
-        Commands::Migrate => {
-            println!("Running database migrations...");
-            virtues.database.initialize().await?;
-            println!("Migrations completed successfully");
+        Commands::Migrate { check } => {
+            if check {
+                // Preflight: report-and-exit, applying nothing. Non-zero exit
+                // on divergence is the contract `virtues upgrade` relies on.
+                let report = virtues.database.migration_check().await?;
+                if !report.pending.is_empty() {
+                    println!(
+                        "pending: {} migration(s) this binary will apply ({}..{})",
+                        report.pending.len(),
+                        report.pending.first().unwrap(),
+                        report.pending.last().unwrap()
+                    );
+                }
+                if report.is_divergent() {
+                    if !report.missing.is_empty() {
+                        eprintln!(
+                            "✖ divergence: migration(s) {:?} are applied in the database but \
+                             missing from this binary — a branch/edge lineage this build does \
+                             not carry. Upgrading across lineages strands them; to cross \
+                             deliberately, reset the DB (`virtues db reset`) or restore a \
+                             matching backup.",
+                            report.missing
+                        );
+                    }
+                    if !report.drifted.is_empty() {
+                        eprintln!(
+                            "✖ divergence: migration(s) {:?} have a different checksum in \
+                             this binary than what was applied — the file changed after being \
+                             applied somewhere.",
+                            report.drifted
+                        );
+                    }
+                    return Err(crate::Error::Other(
+                        "migration lineage divergence — refusing (nothing was applied)"
+                            .to_string(),
+                    )
+                    .into());
+                }
+                println!("✓ lineage OK — this binary can migrate this database");
+            } else {
+                println!("Running database migrations...");
+                virtues.database.initialize().await?;
+                println!("Migrations completed successfully");
+            }
         }
 
         Commands::Server { host, port } => {

--- a/virtues-core/src/cli/restore.rs
+++ b/virtues-core/src/cli/restore.rs
@@ -138,25 +138,14 @@ fn check_schema_compatible(manifest: &Manifest) -> Result<(), crate::Error> {
     Ok(())
 }
 
-/// Read the sqlx migrations directory at build time + report the largest
-/// id. Migrations are named `NNNN_*.sql` in `virtues-core/migrations/`.
+/// The largest migration id this binary ships — read from the EMBEDDED
+/// migration set, so it can never drift from reality. (This replaced a
+/// hand-bumped `KNOWN_MAX_MIGRATION` constant that was still at 9 while the
+/// real set was at 49 — the exact silent-drift failure a derived value
+/// cannot have. Works cold: the embedded set needs no DB connection.)
 fn current_migration_max() -> Option<u64> {
-    // We can't read the source-tree at install time. The simplest stable
-    // signal: ship a compile-time constant updated by the migration script
-    // — but we don't have one. Instead, parse `_sqlx_migrations` at
-    // runtime by connecting; we already do that in `backup.rs`. For
-    // restore, the binary is starting cold (PG may not even be up). So:
-    // hardcode the highest known migration ID in this binary build.
-    //
-    // The number must be bumped any time a new `migrations/NNNN_*.sql`
-    // file is added. CI lints could enforce this, but for v1 it's a
-    // discipline note in PRs.
-    Some(KNOWN_MAX_MIGRATION)
+    crate::database::embedded_migration_max().map(|v| v as u64)
 }
-
-/// Bump this when you add a `migrations/NNNN_*.sql` file. Matches the
-/// largest ID under `virtues-core/migrations/`.
-const KNOWN_MAX_MIGRATION: u64 = 9;
 
 fn verify_sha256(staging: &Path, artifacts: &[Artifact]) -> Result<(), crate::Error> {
     println!("→ verifying sha256 of {} artifact(s)…", artifacts.len());

--- a/virtues-core/src/cli/slots.rs
+++ b/virtues-core/src/cli/slots.rs
@@ -1,0 +1,200 @@
+//! Atomic release slots — the box's whole-release install layout.
+//!
+//! A release is staged as one immutable directory and activated by flipping a
+//! single symlink; every well-known path routes through that link, so a
+//! release changes binary + web + actions **together, atomically**, and
+//! rollback is one flip back. This replaces the in-place per-component swaps
+//! whose partial failures left boxes half-upgraded (the 2026-07-09 brick).
+//!
+//! ```text
+//! /usr/local/share/virtues/
+//!   releases/<slot-id>/        one whole release: virtues, llama-server?,
+//!                              virtues-qnnd?, web/, actions/, actions-bin/
+//!   current -> releases/<id>   THE flip point (atomic rename)
+//!   web     -> current/web     stable paths — env vars & unit files never
+//!   actions -> current/actions change; they resolve through `current`
+//! /usr/local/bin/virtues       -> ../share/virtues/current/virtues
+//! /usr/local/bin/llama-server  -> ../share/virtues/current/llama-server  (if shipped)
+//! /usr/local/bin/virtues-qnnd  -> ../share/virtues/current/virtues-qnnd  (if shipped)
+//! /usr/local/libexec/virtues   -> ../share/virtues/current/actions-bin
+//! ```
+//!
+//! The INSTALLER creates this layout (there is no legacy-layout conversion —
+//! the slot layout shipped before any external box existed); `virtues
+//! upgrade` refuses politely on a box without it. Keep-count is 2: current +
+//! one previous. Rollback needs exactly one prior release; more is hoarding.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// How many release slots to keep (the current one + N-1 previous).
+pub const KEEP_SLOTS: usize = 2;
+
+/// The slot layout rooted at a base dir (`/usr/local/share/virtues` in
+/// production; a temp dir in tests).
+pub struct SlotLayout {
+    base: PathBuf,
+}
+
+impl SlotLayout {
+    pub fn new(base: impl Into<PathBuf>) -> Self {
+        Self { base: base.into() }
+    }
+
+    /// The production layout.
+    pub fn system() -> Self {
+        Self::new("/usr/local/share/virtues")
+    }
+
+    pub fn releases_dir(&self) -> PathBuf {
+        self.base.join("releases")
+    }
+
+    pub fn current_link(&self) -> PathBuf {
+        self.base.join("current")
+    }
+
+    pub fn slot_dir(&self, slot_id: &str) -> PathBuf {
+        self.releases_dir().join(slot_id)
+    }
+
+    /// Is the slot layout present on this box? (`current` exists and is a
+    /// symlink.) Upgrade refuses without it — the installer owns creation.
+    pub fn exists(&self) -> bool {
+        self.current_link().is_symlink()
+    }
+
+    /// The release dir `current` points at, absolute. `None` if the layout is
+    /// absent or the link dangles.
+    pub fn current_slot(&self) -> Option<PathBuf> {
+        let link = self.current_link();
+        let target = fs::read_link(&link).ok()?;
+        let abs = if target.is_absolute() { target } else { self.base.join(target) };
+        abs.canonicalize().ok().filter(|p| p.is_dir())
+    }
+
+    /// Atomically repoint `current` at `slot`: create a temp symlink next to
+    /// it and `rename` over — rename on the same filesystem is atomic, so a
+    /// crash at any instant leaves `current` pointing at a complete release
+    /// (old or new), never nothing.
+    pub fn flip(&self, slot: &Path) -> std::io::Result<()> {
+        let link = self.current_link();
+        let tmp = self.base.join(".current.tmp");
+        let _ = fs::remove_file(&tmp);
+        std::os::unix::fs::symlink(slot, &tmp)?;
+        fs::rename(&tmp, &link)
+    }
+
+    /// The newest release that is NOT current — the rollback target.
+    /// Ordered by directory mtime (set when the slot was staged).
+    pub fn previous_slot(&self) -> Option<PathBuf> {
+        let current = self.current_slot();
+        self.slots_by_age()
+            .into_iter()
+            .find(|p| current.as_ref().map(|c| c != p).unwrap_or(true))
+    }
+
+    /// All slots, newest first (by mtime).
+    fn slots_by_age(&self) -> Vec<PathBuf> {
+        let mut slots: Vec<(std::time::SystemTime, PathBuf)> = fs::read_dir(self.releases_dir())
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter(|e| e.path().is_dir())
+            .filter_map(|e| {
+                let t = e.metadata().ok()?.modified().ok()?;
+                // Canonicalize so comparisons against `current_slot()` (which
+                // canonicalizes) can't be foiled by symlinked tmp paths.
+                Some((t, e.path().canonicalize().ok()?))
+            })
+            .collect();
+        slots.sort_by(|a, b| b.0.cmp(&a.0));
+        slots.into_iter().map(|(_, p)| p).collect()
+    }
+
+    /// Delete all slots beyond the newest `keep`, never touching the one
+    /// `current` resolves to. Best-effort.
+    pub fn prune(&self, keep: usize) {
+        let current = self.current_slot();
+        let mut kept = 0usize;
+        for slot in self.slots_by_age() {
+            let is_current = current.as_ref().map(|c| c == &slot).unwrap_or(false);
+            if is_current || kept < keep {
+                if !is_current {
+                    kept += 1;
+                }
+                continue;
+            }
+            let _ = fs::remove_dir_all(&slot);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("slots-test-{}-{name}", std::process::id()));
+        let _ = fs::remove_dir_all(&d);
+        fs::create_dir_all(d.join("releases")).unwrap();
+        d
+    }
+
+    fn mk_slot(base: &Path, id: &str) -> PathBuf {
+        let p = base.join("releases").join(id);
+        fs::create_dir_all(&p).unwrap();
+        // Distinct mtimes: creation order == age order.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        p
+    }
+
+    #[test]
+    fn flip_is_atomic_and_repoints() {
+        let base = scratch("flip");
+        let layout = SlotLayout::new(&base);
+        let a = mk_slot(&base, "a");
+        let b = mk_slot(&base, "b");
+
+        assert!(!layout.exists());
+        layout.flip(&a).unwrap();
+        assert!(layout.exists());
+        assert_eq!(layout.current_slot().unwrap(), a.canonicalize().unwrap());
+        // Flip over an existing link (the upgrade case).
+        layout.flip(&b).unwrap();
+        assert_eq!(layout.current_slot().unwrap(), b.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn previous_is_newest_non_current() {
+        let base = scratch("prev");
+        let layout = SlotLayout::new(&base);
+        let old = mk_slot(&base, "old");
+        let mid = mk_slot(&base, "mid");
+        let new = mk_slot(&base, "new");
+        layout.flip(&new).unwrap();
+        assert_eq!(layout.previous_slot().unwrap(), mid.canonicalize().unwrap());
+        // After rolling back to mid, previous becomes new (flip-forward target).
+        layout.flip(&mid).unwrap();
+        assert_eq!(layout.previous_slot().unwrap(), new.canonicalize().unwrap());
+        let _ = old;
+    }
+
+    #[test]
+    fn prune_keeps_current_plus_n() {
+        let base = scratch("prune");
+        let layout = SlotLayout::new(&base);
+        let a = mk_slot(&base, "a");
+        let b = mk_slot(&base, "b");
+        let c = mk_slot(&base, "c");
+        layout.flip(&c).unwrap();
+        layout.prune(1); // current + 1 previous
+        assert!(!a.exists(), "oldest pruned");
+        assert!(b.exists(), "previous kept");
+        assert!(c.exists(), "current kept");
+
+        // Current is never pruned even with keep=0.
+        layout.prune(0);
+        assert!(c.exists());
+    }
+}

--- a/virtues-core/src/cli/types.rs
+++ b/virtues-core/src/cli/types.rs
@@ -100,7 +100,15 @@ pub enum Commands {
     },
 
     /// Run database migrations
-    Migrate,
+    Migrate {
+        /// Check lineage only — apply NOTHING. Diffs the DB's applied
+        /// migrations against this binary's embedded set and exits non-zero
+        /// on divergence (applied-but-missing or checksum drift). The upgrade
+        /// preflight runs this under the STAGED binary before any swap, so a
+        /// lineage mismatch is a clean refusal instead of a mid-swap brick.
+        #[arg(long)]
+        check: bool,
+    },
 
     /// Snapshot the box's state into a single tarball.
     ///

--- a/virtues-core/src/cli/types.rs
+++ b/virtues-core/src/cli/types.rs
@@ -196,11 +196,13 @@ pub enum Commands {
         force: bool,
     },
 
-    /// Self-update from the latest GitHub Release.
+    /// Self-update from the latest GitHub Release, via atomic release slots.
     ///
-    /// Stops the service, swaps `/usr/local/bin/virtues` with the new binary
-    /// (keeping one `.bak` for rollback), runs `virtues migrate` to apply
-    /// any schema changes, restarts the service.
+    /// Stages the whole release into `releases/<slot>/`, preflights it (the
+    /// staged binary must pass `migrate --check` + a version smoke test),
+    /// then activates by flipping the `current` symlink — binary + web +
+    /// actions move together. Failures before the flip leave the box
+    /// untouched; failures after flip straight back.
     Upgrade {
         /// Report the available version without changing anything.
         #[arg(long)]
@@ -222,7 +224,20 @@ pub enum Commands {
         /// `--pre`, where the prerelease channel is an explicit opt-in.)
         #[arg(long)]
         force: bool,
+
+        /// Refresh only the named components (comma-separated: `web`,
+        /// `actions`) in the CURRENT release — no binary swap, no migration,
+        /// no restart. The safe fast path for UI iteration.
+        #[arg(long)]
+        only: Option<String>,
     },
+
+    /// Flip back to the previous release slot and restart.
+    ///
+    /// The atomic inverse of `upgrade`: one symlink flip restores binary +
+    /// web + actions together. Schema is not rolled back (migrations only go
+    /// forward); the previous binary tolerates a newer schema.
+    Rollback,
 
     /// Start the HTTP server
     #[command(hide = true)]

--- a/virtues-core/src/cli/upgrade.rs
+++ b/virtues-core/src/cli/upgrade.rs
@@ -1,10 +1,11 @@
-//! `virtues upgrade` — self-update from a GitHub Release.
+//! `virtues upgrade` — self-update from a GitHub Release, via atomic slots.
 //!
-//! Stops the service, swaps `/usr/local/bin/virtues` with the downloaded
-//! binary (keeping one `.bak` for rollback), applies any pending DB
-//! migrations under the new binary, restarts the service. On any failure
-//! mid-swap the rollback command is printed verbatim so a tired operator at
-//! 2 AM can paste it without thinking.
+//! A release is staged whole into `releases/<slot>/`, preflighted (the STAGED
+//! binary runs `migrate --check` + a `--version` smoke before anything is
+//! touched), then activated by flipping the `current` symlink — binary + web
+//! + actions move together, atomically. Any failure before the flip leaves
+//! the box byte-identical; any failure after flips straight back. `virtues
+//! rollback` is the same flip in reverse. See `cli/slots.rs` for the layout.
 //!
 //! Strictly opt-in. No background auto-upgrade — that lands when the
 //! upgrade path has been battle-tested.
@@ -19,7 +20,7 @@ use semver::Version;
 
 use sha2::{Digest, Sha256};
 
-use super::ui;
+use super::{slots, ui};
 
 const BINARY_PATH: &str = "/usr/local/bin/virtues";
 const RELEASE_REPO: &str = "virtues-os/virtues";
@@ -30,6 +31,7 @@ pub async fn run(
     version: Option<String>,
     pre: bool,
     force: bool,
+    only: Option<String>,
 ) -> Result<(), crate::Error> {
     let target_tag = match version {
         Some(v) => v,
@@ -44,8 +46,14 @@ pub async fn run(
     ui::kv("target", target);
     println!();
 
-    if target == current {
-        ui::ok(&format!("already on {current} — nothing to do"));
+    // Cheap no-op detection works only for STABLE tags, where the semver is
+    // the whole identity. Prerelease/edge builds all report the bare crate
+    // version, so equality there means nothing — those fall through to the
+    // SHA comparison after download (the fix for "edge→edge is impossible").
+    // `--force` bypasses every equality short-circuit.
+    let is_stable_tag = !target.contains('-') && target.chars().next().is_some_and(|c| c.is_ascii_digit());
+    if !force && is_stable_tag && target == current {
+        ui::ok(&format!("already on {current} — nothing to do (--force to reinstall)"));
         return Ok(());
     }
     if check {
@@ -112,30 +120,146 @@ pub async fn run(
     let extracted = work_path.join("extracted");
 
     // Which artifacts this tarball actually carries. Older releases ship a
-    // subset — every one is optional and best-effort so an upgrade from any
-    // historical tarball still swaps whatever it can. `virtues` itself is the
-    // only mandatory member (already located by `extract_binary`).
+    // subset — every member but `virtues` itself is optional.
     let new_llama = find_named(&extracted, "llama-server").ok();
+    let new_qnnd = find_named(&extracted, "virtues-qnnd").ok();
     let web_src = find_dir_named(&extracted, "web").ok();
     let actions_src = find_dir_named(&extracted, "actions").ok();
     let actions_bin_src = find_dir_named(&extracted, "actions-bin").ok();
 
-    let dirs = InstallDirs::resolve();
+    // Build identity from the tarball's BUILD.json (releases since the slot
+    // era carry one). The SHA is the only honest identity for prerelease
+    // builds — every edge build reports the same crate version.
+    let build = read_build_manifest(&extracted);
+    if !force {
+        if let Some(sha) = build.as_ref().and_then(|b| b.sha.as_deref()) {
+            let running = env!("GIT_COMMIT");
+            if !running.is_empty() && running != "unknown" && sha.starts_with(&running[..running.len().min(7)]) {
+                ui::ok(&format!(
+                    "already on this exact build ({}) — nothing to do (--force to reinstall)",
+                    &sha[..sha.len().min(7)]
+                ));
+                return Ok(());
+            }
+        }
+    }
+
+    // ── `--only web[,actions]` — the fast path ──────────────────────────────
+    // Refresh just the named components IN the current slot, no binary swap,
+    // no migration, no restart (web is static files; actions are re-globbed).
+    // Deliberately mutates the live slot: this is the dev/UI iteration loop,
+    // not a release activation.
+    if let Some(list) = only {
+        let dirs = InstallDirs::resolve();
+        for part in list.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+            match part {
+                "web" => match &web_src {
+                    Some(src) => refresh_named("web UI", src, &canonical(&dirs.web)),
+                    None => ui::warn("tarball carries no web/ — skipped"),
+                },
+                "actions" => {
+                    match &actions_src {
+                        Some(src) => refresh_named("actions", src, &canonical(&dirs.actions)),
+                        None => ui::warn("tarball carries no actions/ — skipped"),
+                    }
+                    match &actions_bin_src {
+                        Some(src) => {
+                            refresh_named("action binaries", src, &canonical(&dirs.actions_bin))
+                        }
+                        None => ui::warn("tarball carries no actions-bin/ — skipped"),
+                    }
+                }
+                other => {
+                    return Err(crate::Error::Other(format!(
+                        "--only {other}: unknown component (web, actions)"
+                    )))
+                }
+            }
+        }
+        println!();
+        ui::ok(&format!("refreshed --only components from {target_tag}"));
+        return Ok(());
+    }
+
+    // ── Slot layout required from here on ───────────────────────────────────
+    let layout = slots::SlotLayout::system();
+    if !layout.exists() {
+        return Err(crate::Error::Other(
+            "this box predates release slots (no `current` link under \
+             /usr/local/share/virtues). Re-run the installer once to adopt the \
+             slot layout:\n\n  curl -sSL https://virtues.com/sh | sudo sh\n"
+                .to_string(),
+        ));
+    }
+    let prior_slot = layout.current_slot();
+
+    // ── Stage the whole release into its slot ───────────────────────────────
+    let slot_id = build
+        .as_ref()
+        .and_then(|b| b.slot_id(&target_tag))
+        .unwrap_or_else(|| format!("{target_tag}-{}", chrono::Utc::now().format("%Y%m%dT%H%M%S")));
+    let slot = layout.slot_dir(&slot_id);
+    ui::step(&format!("staging release into {}…", slot.display()));
+    stage_slot(&slot, &new_binary, &new_llama, &new_qnnd, &web_src, &actions_src, &actions_bin_src)?;
+
+    // ── Preflight — the STAGED binary must prove itself before any swap ────
+    // 1. `--version` smoke: the binary runs on this box at all.
+    // 2. `migrate --check`: lineage compatibility, applying nothing. This is
+    //    what turns "brick mid-swap on a migration mismatch" into a clean
+    //    refusal with the box untouched. `--force` skips only the lineage
+    //    gate (older targets don't know `--check`), never the smoke test.
+    let staged_bin = slot.join("virtues");
+    ui::step("preflight: staged binary smoke test…");
+    match Command::new(&staged_bin).arg("--version").output() {
+        Ok(o) if o.status.success() => {
+            ui::ok(&format!("staged: {}", String::from_utf8_lossy(&o.stdout).trim()));
+        }
+        Ok(o) => {
+            let _ = fs::remove_dir_all(&slot);
+            return Err(crate::Error::Other(format!(
+                "staged binary failed --version (exit {}); box untouched",
+                o.status
+            )));
+        }
+        Err(e) => {
+            let _ = fs::remove_dir_all(&slot);
+            return Err(crate::Error::Other(format!(
+                "staged binary would not run ({e}); box untouched"
+            )));
+        }
+    }
+    if !force {
+        ui::step("preflight: migration lineage check…");
+        match Command::new(&staged_bin).args(["migrate", "--check"]).output() {
+            Ok(o) if o.status.success() => ui::ok("lineage OK"),
+            Ok(o) => {
+                let _ = fs::remove_dir_all(&slot);
+                eprintln!("{}", String::from_utf8_lossy(&o.stderr).trim_end());
+                return Err(crate::Error::Other(
+                    "migration preflight refused this release — box untouched \
+                     (see reason above; `--force` overrides at your own risk)"
+                        .to_string(),
+                ));
+            }
+            Err(e) => {
+                let _ = fs::remove_dir_all(&slot);
+                return Err(crate::Error::Other(format!(
+                    "could not run migration preflight ({e}); box untouched"
+                )));
+            }
+        }
+    }
 
     // Relay migration: an upgrade from a WireGuard-era release has an orphaned
-    // `virtues-wireguard.service` (the box now reaches via the relay). Stop +
-    // disable it so it doesn't idle forever reconciling a wg0 nothing creates.
-    // Best-effort; a no-op on boxes that never had it.
+    // `virtues-wireguard.service`. Best-effort; no-op on boxes that never had it.
     disable_legacy_wireguard();
 
-    // ── Stop affected services ──────────────────────────────────────────────
-    // The main app always. The inference sidecars only when we're actually
-    // replacing their binaries — restarting the sidecars reloads multi-GB GGUFs
-    // (slow), so don't pay that cost for a binary-only app upgrade. A running process holds the old inode until restarted, so the
-    // stop→swap→start ordering is what makes the new bytes take effect.
+    // ── Stop → flip → migrate → start ───────────────────────────────────────
+    // Sidecars restart only when the release replaces their binaries
+    // (reloading multi-GB GGUFs is slow; don't pay it for an app-only bump).
     ui::step("stopping virtues.service…");
     service_stop("virtues");
-    let sidecars = if new_llama.is_some() {
+    let sidecars = if new_llama.is_some() || new_qnnd.is_some() {
         installed_inference_units()
     } else {
         Vec::new()
@@ -144,101 +268,50 @@ pub async fn run(
         service_stop(unit);
     }
 
-    // Bring the sidecars we stopped back up. Called on every abort path below
-    // so a failed upgrade doesn't leave the box with dead search — without this,
-    // stopping `virtues-embed`/`-rerank` early then returning on a migrate or
-    // start failure left them down until a manual `systemctl start`. Idempotent
-    // and best-effort.
-    let to_revive = sidecars.clone();
-    let revive_sidecars = move || {
-        for unit in &to_revive {
+    // On any failure after this point: flip back to the prior slot and
+    // restart, so the box always runs a COMPLETE release (binary + web +
+    // actions together — the old per-component path could not promise that).
+    let flip_back = |layout: &slots::SlotLayout, why: String| -> crate::Error {
+        if let Some(prior) = &prior_slot {
+            let _ = layout.flip(prior);
+            ui::warn(&format!("rolled back to {}", prior.display()));
+        }
+        let _ = service_start("virtues");
+        for unit in &sidecars {
             let _ = service_start(unit);
         }
+        crate::Error::Other(why)
     };
 
-    // ── Swap the main binary (mandatory; keep .bak for rollback) ────────────
-    let bak = match swap_with_bak(&new_binary, Path::new(BINARY_PATH)) {
-        Ok(b) => b.unwrap_or_else(|| format!("{BINARY_PATH}.bak")),
-        Err(e) => {
-            // Nothing irreversible happened yet (swap_with_bak restores the
-            // original on failure), but be explicit about the manual path.
-            revive_sidecars();
-            print_rollback_hint(&format!("{BINARY_PATH}.bak"));
-            return Err(e);
-        }
-    };
-    ui::ok(&format!("swapped {BINARY_PATH} (rollback copy at {bak})"));
-
-    // ── Swap the sidecar binaries (best-effort; they sit next to `virtues`) ─
-    // A failed sidecar swap must not abort an otherwise-good app upgrade —
-    // swap_with_bak restores the prior binary on failure, so the box keeps a
-    // working sidecar. We warn and continue.
-    if let Some(src) = &new_llama {
-        let dst = dirs.bin_dir.join("llama-server");
-        match swap_with_bak(src, &dst) {
-            Ok(_) => ui::ok(&format!("swapped {}", dst.display())),
-            Err(e) => ui::warn(&format!("llama-server not swapped ({e}); prior binary kept")),
-        }
-    }
-
-    // ── Refresh the shipped directories (best-effort, atomic per-dir) ───────
-    // web/: a binary-only swap leaves the browser served a stale SvelteKit
-    // build. actions/: manifests + UI the server globs at runtime.
-    // actions-bin/: the compiled per-source action executables the box forks
-    // by name — the one whose staleness caused the rustls "No provider set"
-    // panic that motivated making this path complete.
-    if let Some(src) = &web_src {
-        refresh_named("web UI", src, &dirs.web);
-    }
-    if let Some(src) = &actions_src {
-        refresh_named("actions", src, &dirs.actions);
-    }
-    if let Some(src) = &actions_bin_src {
-        refresh_named("action binaries", src, &dirs.actions_bin);
+    ui::step("activating release (symlink flip)…");
+    if let Err(e) = layout.flip(&slot) {
+        return Err(flip_back(&layout, format!("could not flip current → {slot_id}: {e}")));
     }
 
     ui::step("running migrations under the new binary…");
-    let migrate = Command::new(BINARY_PATH).arg("migrate").status();
-    match migrate {
+    match Command::new(BINARY_PATH).arg("migrate").status() {
         Ok(s) if s.success() => {}
         Ok(s) => {
-            revive_sidecars();
-            print_rollback_hint(&bak);
-            return Err(crate::Error::Other(format!(
-                "new binary's `migrate` exited {s}"
-            )));
+            return Err(flip_back(
+                &layout,
+                format!("new binary's `migrate` exited {s} — rolled back"),
+            ))
         }
-        Err(e) => {
-            revive_sidecars();
-            print_rollback_hint(&bak);
-            return Err(crate::Error::Other(format!("invoke migrate: {e}")));
-        }
+        Err(e) => return Err(flip_back(&layout, format!("invoke migrate: {e} — rolled back"))),
     }
 
-    // The box keeps its default `virtues.local` name (no in-app rename step),
-    // so the old hostname-rename sudoers grant is dead. Remove it from boxes
-    // that were installed when the rename step still existed. Best-effort.
+    // The box keeps its default `virtues.local` name; remove the dead
+    // hostname-rename sudoers grant from older installs. Best-effort.
     remove_stale_setup_sudoers();
 
-    // ── Start services back up ──────────────────────────────────────────────
-    // The main app is the one whose failure aborts (and prints the rollback
-    // hint); the sidecars are best-effort restarts that won't undo a good app
-    // upgrade — but a sidecar that won't start means degraded search, so warn
-    // loudly.
     ui::step("starting virtues.service…");
     match service_start("virtues") {
         Ok(true) => {}
-        Ok(false) => {
-            revive_sidecars();
-            print_rollback_hint(&bak);
-            return Err(crate::Error::Other(
-                "systemctl start virtues failed".to_string(),
-            ));
-        }
-        Err(e) => {
-            revive_sidecars();
-            print_rollback_hint(&bak);
-            return Err(crate::Error::Other(format!("invoke systemctl: {e}")));
+        _ => {
+            return Err(flip_back(
+                &layout,
+                "systemctl start virtues failed on the new release — rolled back".to_string(),
+            ))
         }
     }
     for unit in &sidecars {
@@ -248,6 +321,9 @@ pub async fn run(
             ));
         }
     }
+
+    // Keep current + one previous; delete older slots.
+    layout.prune(slots::KEEP_SLOTS - 1);
 
     // Model-set drift check. `virtues upgrade` swaps binaries but does NOT
     // fetch model GGUFs or rewrite the sidecar `-m`/pooling in the unit files —
@@ -291,9 +367,152 @@ pub async fn run(
     }
 
     println!();
-    ui::ok(&format!("upgraded to {target_tag} — rollback copy kept at {bak}"));
+    ui::ok(&format!(
+        "upgraded to {target_tag} (slot {slot_id}) — `virtues rollback` restores the previous release"
+    ));
     println!();
     Ok(())
+}
+
+/// `virtues rollback` — flip `current` back to the previous release slot and
+/// restart. The inverse of an upgrade's activation: one atomic symlink flip
+/// moves binary + web + actions together. No migrations run — schema rolls
+/// FORWARD only; a rolled-back binary boots with `ignore_missing`, so a
+/// newer-schema DB is tolerated (features that need the newer binary are
+/// simply gone until you upgrade again).
+pub async fn rollback() -> Result<(), crate::Error> {
+    ui::section("Rollback");
+    let layout = slots::SlotLayout::system();
+    if !layout.exists() {
+        return Err(crate::Error::Other(
+            "no release slots on this box (re-run the installer once to adopt the slot layout)"
+                .to_string(),
+        ));
+    }
+    let current = layout
+        .current_slot()
+        .ok_or_else(|| crate::Error::Other("current release link dangles".to_string()))?;
+    let Some(previous) = layout.previous_slot() else {
+        return Err(crate::Error::Other(
+            "no previous release kept — nothing to roll back to".to_string(),
+        ));
+    };
+    ui::kv("current", &current.file_name().unwrap_or_default().to_string_lossy());
+    ui::kv("target", &previous.file_name().unwrap_or_default().to_string_lossy());
+    println!();
+
+    if !running_as_root() {
+        return Err(crate::Error::Other(
+            "virtues rollback must run as root (try with sudo)".to_string(),
+        ));
+    }
+    let _lock = acquire_lock()?;
+
+    ui::step("stopping services…");
+    service_stop("virtues");
+    let sidecars = installed_inference_units();
+    for unit in &sidecars {
+        service_stop(unit);
+    }
+
+    ui::step("flipping current → previous release…");
+    layout
+        .flip(&previous)
+        .map_err(|e| crate::Error::Other(format!("flip failed: {e}")))?;
+
+    ui::step("starting services…");
+    match service_start("virtues") {
+        Ok(true) => {}
+        _ => {
+            // Roll forward again rather than leave the box down on a release
+            // that won't boot.
+            let _ = layout.flip(&current);
+            let _ = service_start("virtues");
+            for unit in &sidecars {
+                let _ = service_start(unit);
+            }
+            return Err(crate::Error::Other(
+                "previous release would not start — flipped forward again".to_string(),
+            ));
+        }
+    }
+    for unit in &sidecars {
+        let _ = service_start(unit);
+    }
+
+    println!();
+    ui::ok("rolled back — the previous release is active");
+    Ok(())
+}
+
+/// The tarball's build identity, written by CI next to the binaries.
+#[derive(serde::Deserialize)]
+struct BuildManifest {
+    version: Option<String>,
+    sha: Option<String>,
+}
+
+impl BuildManifest {
+    /// Directory name for this release's slot: `<tag>-<sha7>`. Unique per
+    /// build (two edge cuts differ by sha), stable per artifact (re-running
+    /// an upgrade re-stages the same slot).
+    fn slot_id(&self, tag: &str) -> Option<String> {
+        let sha = self.sha.as_deref()?;
+        Some(format!("{tag}-{}", &sha[..sha.len().min(7)]))
+    }
+}
+
+/// Read `BUILD.json` from the extracted tarball. Absent on pre-slot-era
+/// releases — every consumer treats it as optional.
+fn read_build_manifest(extracted: &Path) -> Option<BuildManifest> {
+    let p = find_named(extracted, "BUILD.json").ok()?;
+    serde_json::from_slice(&fs::read(p).ok()?).ok()
+}
+
+/// Copy one whole release into its slot dir. The slot is the unit of
+/// activation and rollback, so it carries EVERYTHING the tarball shipped;
+/// only `virtues` itself is mandatory.
+fn stage_slot(
+    slot: &Path,
+    binary: &Path,
+    llama: &Option<PathBuf>,
+    qnnd: &Option<PathBuf>,
+    web: &Option<PathBuf>,
+    actions: &Option<PathBuf>,
+    actions_bin: &Option<PathBuf>,
+) -> Result<(), crate::Error> {
+    // Re-staging the same slot id (a retried upgrade) starts clean.
+    let _ = fs::remove_dir_all(slot);
+    fs::create_dir_all(slot)
+        .map_err(|e| crate::Error::Other(format!("mkdir {}: {e}", slot.display())))?;
+
+    let copy_bin = |src: &Path, name: &str| -> Result<(), crate::Error> {
+        let dst = slot.join(name);
+        fs::copy(src, &dst)
+            .map_err(|e| crate::Error::Other(format!("stage {name}: {e}")))?;
+        fs::set_permissions(&dst, fs::Permissions::from_mode(0o755))
+            .map_err(|e| crate::Error::Other(format!("chmod {name}: {e}")))?;
+        Ok(())
+    };
+    copy_bin(binary, "virtues")?;
+    if let Some(p) = llama {
+        copy_bin(p, "llama-server")?;
+    }
+    if let Some(p) = qnnd {
+        copy_bin(p, "virtues-qnnd")?;
+    }
+    for (src, name) in [(web, "web"), (actions, "actions"), (actions_bin, "actions-bin")] {
+        if let Some(s) = src {
+            copy_dir_all(s, &slot.join(name))?;
+        }
+    }
+    Ok(())
+}
+
+/// Resolve a well-known path through its symlinks to the real directory —
+/// `--only` must write INTO the current slot, not replace the routing link.
+fn canonical(p: &Path) -> PathBuf {
+    p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
 }
 
 /// Read a single `KEY=value` from the box env file (`/var/lib/virtues/virtues.env`).
@@ -347,27 +566,6 @@ impl InstallDirs {
             actions_bin: env_dir("VIRTUES_ACTIONS_BIN_DIR", "/usr/local/libexec/virtues"),
         }
     }
-}
-
-/// Replace `dest` with `new`, keeping the prior file as `dest.bak` for
-/// rollback. Restores the original if the swap fails partway, so a caller that
-/// treats a failure as non-fatal still has a working binary in place. Returns
-/// the `.bak` path when one was created (`None` for a fresh install).
-fn swap_with_bak(new: &Path, dest: &Path) -> Result<Option<String>, crate::Error> {
-    let bak = format!("{}.bak", dest.display());
-    let had_prior = dest.exists();
-    if had_prior {
-        let _ = fs::remove_file(&bak);
-        fs::rename(dest, &bak)
-            .map_err(|e| crate::Error::Other(format!("rename {} to {bak}: {e}", dest.display())))?;
-    }
-    if let Err(e) = swap_binary(new, dest) {
-        if had_prior {
-            let _ = fs::rename(&bak, dest); // put the working binary back
-        }
-        return Err(e);
-    }
-    Ok(had_prior.then_some(bak))
 }
 
 /// Atomically replace a shipped directory, logging a uniform success/skip line.
@@ -781,30 +979,6 @@ fn find_named(dir: &Path, name: &str) -> Result<PathBuf, crate::Error> {
     Err(crate::Error::Other(format!(
         "{name} not found inside the release tarball"
     )))
-}
-
-fn swap_binary(new_binary: &Path, dest: &Path) -> Result<(), crate::Error> {
-    // `fs::rename` is atomic when src + dst share a filesystem. The
-    // extracted binary may not — fall back to copy + remove.
-    if fs::rename(new_binary, dest).is_err() {
-        fs::copy(new_binary, dest)
-            .map_err(|e| crate::Error::Other(format!("copy new binary to {}: {e}", dest.display())))?;
-    }
-    fs::set_permissions(dest, fs::Permissions::from_mode(0o755))
-        .map_err(|e| crate::Error::Other(format!("chmod {}: {e}", dest.display())))?;
-    Ok(())
-}
-
-/// Stays on stderr and deliberately unstyled beyond the marker: this is the
-/// paste-at-2AM block, and it must survive any capture/pipe intact.
-fn print_rollback_hint(bak: &str) {
-    eprintln!();
-    eprintln!("  ✖  upgrade failed mid-swap. Roll back with:");
-    eprintln!();
-    eprintln!("       sudo systemctl stop virtues");
-    eprintln!("       sudo mv {bak} {BINARY_PATH}");
-    eprintln!("       sudo systemctl start virtues");
-    eprintln!();
 }
 
 struct Stage(PathBuf);

--- a/virtues-core/src/cli/upgrade.rs
+++ b/virtues-core/src/cli/upgrade.rs
@@ -586,10 +586,24 @@ fn refresh_named(label: &str, src: &Path, dst: &Path) {
 /// set is wrong for the other — assuming llama.cpp made a healthy Q6A box print
 /// "Unit virtues-embed.service not loaded" and a false "search/embeddings degraded"
 /// on every upgrade. So ask the filesystem instead of guessing.
-fn installed_inference_units() -> Vec<&'static str> {
+fn installed_inference_units() -> Vec<String> {
+    // Prefer the installer's topology manifest — DECLARED shape, not a guess.
+    if let Ok(bytes) = fs::read("/usr/local/share/virtues/install.json") {
+        if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&bytes) {
+            if let Some(units) = v.get("sidecars").and_then(|s| s.as_array()) {
+                return units
+                    .iter()
+                    .filter_map(|u| u.as_str().map(str::to_string))
+                    .collect();
+            }
+        }
+    }
+    // Fallback for boxes installed before the manifest existed: ask the
+    // filesystem which unit files are present.
     ["virtues-embed", "virtues-rerank", "virtues-qnnd"]
         .into_iter()
         .filter(|u| Path::new(&format!("/etc/systemd/system/{u}.service")).exists())
+        .map(str::to_string)
         .collect()
 }
 

--- a/virtues-core/src/database/mod.rs
+++ b/virtues-core/src/database/mod.rs
@@ -287,6 +287,10 @@ impl Database {
     /// Run database migrations
     async fn run_migrations(&self) -> Result<()> {
         let mut migrator = sqlx::migrate!("./migrations");
+        // NOTE: `ignore_missing` below means BOOT does not enforce lineage —
+        // deliberate (one dev DB serves many branches). The enforcement point
+        // is `virtues migrate --check` (migration_check), which the upgrade
+        // path runs BEFORE swapping anything. See docs/update-paradigm.md.
         // One dev database serves many branches: a migration applied on a
         // feature branch must not brick `make dev` on branches that don't
         // carry its file. Skip applied-but-unknown versions instead.
@@ -296,6 +300,43 @@ impl Database {
             .await
             .map_err(|e| Error::Database(format!("Failed to run migrations: {e}")))?;
         Ok(())
+    }
+
+    /// Lineage check between the DB's applied migrations and this binary's
+    /// embedded set — **applies nothing**. This is the upgrade preflight: run
+    /// under the *staged* binary before any swap, it turns "brick mid-swap on
+    /// a migration mismatch" into a clean pre-swap refusal.
+    pub async fn migration_check(&self) -> Result<MigrationCheck> {
+        let embedded: std::collections::BTreeMap<i64, &[u8]> = EMBEDDED_MIGRATIONS
+            .iter()
+            .map(|m| (m.version, m.checksum.as_ref()))
+            .collect();
+
+        // A fresh DB (no _sqlx_migrations table yet) has nothing applied —
+        // every embedded migration is pending, no divergence possible.
+        let applied: Vec<(i64, Vec<u8>)> = match sqlx::query_as(
+            "SELECT version, checksum FROM _sqlx_migrations ORDER BY version",
+        )
+        .fetch_all(&self.pool)
+        .await
+        {
+            Ok(rows) => rows,
+            Err(_) => Vec::new(),
+        };
+
+        let mut check = MigrationCheck::default();
+        for (version, checksum) in &applied {
+            match embedded.get(version) {
+                None => check.missing.push(*version),
+                Some(c) if *c != checksum.as_slice() => check.drifted.push(*version),
+                Some(_) => {}
+            }
+        }
+        let applied_set: std::collections::BTreeSet<i64> =
+            applied.iter().map(|(v, _)| *v).collect();
+        check.pending =
+            embedded.keys().filter(|v| !applied_set.contains(v)).copied().collect();
+        Ok(check)
     }
 
     /// Execute a query with parameters
@@ -403,5 +444,39 @@ mod tests {
     #[test]
     fn test_normalize_errors_when_unset() {
         assert!(normalize_from(None).is_err());
+    }
+}
+
+/// This binary's embedded migration set — the single source of truth for
+/// "which migrations does this build know". Shared by `migration_check` (the
+/// upgrade preflight) and restore's schema-compatibility gate, so neither can
+/// drift from the real set the way the old hand-bumped `KNOWN_MAX_MIGRATION`
+/// constant did.
+pub static EMBEDDED_MIGRATIONS: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
+/// The largest migration version this binary ships. `None` only for a build
+/// with an empty migrations dir (never in practice).
+pub fn embedded_migration_max() -> Option<i64> {
+    EMBEDDED_MIGRATIONS.iter().map(|m| m.version).max()
+}
+
+/// Result of [`Database::migration_check`]: how the DB's applied migrations
+/// relate to this binary's embedded set. `missing`/`drifted` are DIVERGENCE
+/// (refuse to upgrade across them); `pending` is the normal forward case.
+#[derive(Debug, Default)]
+pub struct MigrationCheck {
+    /// Applied in the DB but absent from this binary — a branch/edge lineage
+    /// this build does not carry. Upgrading would strand them.
+    pub missing: Vec<i64>,
+    /// Applied with a different checksum than this binary ships — the file
+    /// was edited after being applied somewhere.
+    pub drifted: Vec<i64>,
+    /// In this binary but not yet applied — what a normal `migrate` will run.
+    pub pending: Vec<i64>,
+}
+
+impl MigrationCheck {
+    pub fn is_divergent(&self) -> bool {
+        !self.missing.is_empty() || !self.drifted.is_empty()
     }
 }

--- a/virtues-core/src/main.rs
+++ b/virtues-core/src/main.rs
@@ -508,11 +508,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Self-update from the latest GitHub Release (or a pinned --version
     // tag). Stops the service, swaps the binary, applies migrations,
     // restarts. Detailed in `virtues::cli::upgrade`.
-    if let Some(Commands::Upgrade { check, version, pre, force }) = &cli.command {
-        match virtues::cli::upgrade::run(*check, version.clone(), *pre, *force).await {
+    if let Some(Commands::Upgrade { check, version, pre, force, only }) = &cli.command {
+        match virtues::cli::upgrade::run(*check, version.clone(), *pre, *force, only.clone()).await
+        {
             Ok(()) => return Ok(()),
             Err(e) => {
                 eprintln!("error: upgrade failed: {e}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // ─── `virtues rollback` ─────────────────────────────────────────────────
+    // Flip `current` back to the previous release slot and restart — the
+    // atomic inverse of an upgrade's activation. Like Upgrade, needs no DB.
+    if let Some(Commands::Rollback) = &cli.command {
+        match virtues::cli::upgrade::rollback().await {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                eprintln!("error: rollback failed: {e}");
                 std::process::exit(1);
             }
         }

--- a/virtues-core/src/tools/action_setup.rs
+++ b/virtues-core/src/tools/action_setup.rs
@@ -93,7 +93,21 @@ pub async fn execute(
     let config = serde_json::json!({ "chat_id": chat_id });
     let config_json = config.to_string();
 
-    let action_id = format!("action_agent_{}", chat_id);
+    // One row per (chat, name): the name slug is part of the id so a chat can
+    // own several actions. Re-running with the same name updates in place; a
+    // new name creates a sibling instead of silently overwriting.
+    let mut slug = String::new();
+    for c in name.to_lowercase().chars() {
+        if c.is_ascii_alphanumeric() {
+            slug.push(c);
+        } else if !slug.ends_with('_') && !slug.is_empty() {
+            slug.push('_');
+        }
+    }
+    let slug = slug.trim_end_matches('_');
+    let slug = if slug.is_empty() { "applet" } else { slug };
+    let slug = &slug[..slug.len().min(48)];
+    let action_id = format!("action_agent_{}_{}", chat_id, slug);
 
     sqlx::query(
         r#"


### PR DESCRIPTION
Phase 2 of the update manifold — the anti-brick work. Every piece traces to a documented failure on the lab box (the 2026-07-09 mid-swap brick; today's stale-inode discovery).

## The three commits
1. **`virtues migrate --check`** — diffs the DB's applied migrations against the binary's embedded set, exits non-zero on divergence (applied-but-missing lineage / checksum drift), **applying nothing**. Also: restore's schema gate is now *derived* from the embedded set — the hand-bumped `KNOWN_MAX_MIGRATION` was still **9** while the real set is at **49** (silently broken; can't drift anymore).
2. **Atomic release slots + `virtues rollback`** — upgrade = stage whole release into `releases/<tag>-<sha7>/` → preflight (staged binary must pass `--version` smoke + `migrate --check`) → **flip `current`** (binary+web+actions activate together) → migrate → restart. Pre-flip failure: box byte-identical. Post-flip failure: flips back + restarts. `rollback` = the inverse flip (and flips forward again if the previous release won't start). Keep = current + 1. CI writes **`BUILD.json`** into the tarball; SHA comparison fixes "edge→edge is impossible", with `--force` above every short-circuit. **`--only web,actions`** = the no-restart fast path (replaces the manual rsync loop).
3. **Installer: native slot layout + `install.json`** — installer stages/flips/maintains the routing symlinks (units + env never change across releases — everything resolves through `current`); re-running it on a pre-slot box is the one-time adoption. `install.json` declares `{profile, sidecars, models_dir}`; upgrade reads it instead of sniffing unit files (fallback sniff kept).

Deliberately **not** built (scope trims agreed): keep-N config/GC, auto-update, scheduled windows, legacy-layout conversion machinery (pre-publish, one box — the installer rerun *is* the adoption).

Fixes today's discovered gotcha structurally: services always restart around a flip, so no more stale-inode-keeps-serving.

## Verified
- `cargo check` clean (core + installer), slots module 3/3 tempdir tests (atomic flip, previous-slot selection, prune-never-touches-current), workflow YAML valid.
- **Not yet box-validated** — needs the edge→Dragon loop: cut edge from this branch, reinstall (adopts slot layout), then `upgrade` + `rollback` + `upgrade` again on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)